### PR TITLE
Various improvements

### DIFF
--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -97,10 +97,10 @@ Content-Type: application/json; charset=utf-8
           },
           "bands":8
         },
-        "left":16.1,
-        "right":16.6,
-        "top":48.6,
-        "bottom":47.2
+        "west":16.1,
+        "east":16.6,
+        "north":48.6,
+        "south":47.2
       },
       "extent":[
         "2017-01-01T00:00:00Z",

--- a/openapi.json
+++ b/openapi.json
@@ -229,7 +229,7 @@
     "/output_formats": {
       "get": {
         "summary": "List supported output formats.",
-        "description": "The request will ask the back-end for supported output formats, e.g. PNG, GTiff and JSON, and its default output format. The response is an object of the default and all available output formats and their options. This does not include the supported web services.\n\n**Note**: Output format names and parameters SHOULD be fully aligned with the GDAL codes if available, see [GDAL Raster Formats](http://www.gdal.org/formats_list.html) and [OGR Vector Formats](http://www.gdal.org/ogr_formats.html). It is OPTIONAL to support all output format parameters supported by GDAL. Some file formats not available through GDAL could be defined centrally for openEO. Custom output formats or parameters MAY be defined, but it is recommended to stick to GDAL to increase interoperability.\n\nA `JSON` file format MAY be supported by back-ends to allow outputting data that doesn't fit into raster or vector file formats.\n\nFile formats that define multiple GIS spatial data types in `gis_data_types` (e.g.  raster and vector) SHOULD define a parameter `gis_data_type` in the `parameters` for the output format to allow speciying which data type should be used for writing job or other results.\n\nOutput format names are allowed to be *case insensitive* throughout the API.",
+        "description": "The request will ask the back-end for supported output formats, e.g. PNG, GTiff and JSON, and its default output format. The response is an object of the default and all available output formats and their options. This does not include the supported web services.\n\n**Note**: Output format names and parameters SHOULD be fully aligned with the GDAL codes if available, see [GDAL Raster Formats](http://www.gdal.org/formats_list.html) and [OGR Vector Formats](http://www.gdal.org/ogr_formats.html). It is OPTIONAL to support all output format parameters supported by GDAL. Some file formats not available through GDAL could be defined centrally for openEO. Custom output formats or parameters MAY be defined, but it is recommended to stick to GDAL to increase interoperability.\n\nA `JSON` file format MAY be supported by back-ends to allow outputting data that doesn't fit into raster or vector file formats.\n\nFile formats that define multiple GIS spatial data types in `gis_data_types` (e.g. raster and vector) SHOULD define a parameter `gis_data_type` in the `parameters` for the output format to allow speciying which data type should be used for writing job or other results.\n\nOutput format names are allowed to be *case insensitive* throughout the API.",
         "tags": [
           "Capabilities",
           "Job Management"
@@ -401,7 +401,7 @@
     "/collections": {
       "get": {
         "summary": "List available EO datasets/collections.",
-        "description": "Requests will ask the back-end for available collections and will return an  array of available collections with very basic information such as their unique identifiers.\n\nMore information on [data discovery](https://open-eo.github.io/openeo-api/v/0.3.0/collections/), including common relation types for links, are available in the documentation.\n\n**Note:** openEO strives for compatibility with [STAC](https://github.com/radiantearth/stac-spec) and [OGC WFS 3.0](https://github.com/opengeospatial/WFS_FES) as far as possible. Both standards, as well as openEO, are still under development. Therefore, it is likely that further changes and adjustments will be made in the future.",
+        "description": "Requests will ask the back-end for available collections and will return an array of available collections with very basic information such as their unique identifiers.\n\nMore information on [data discovery](https://open-eo.github.io/openeo-api/v/0.3.0/collections/), including common relation types for links, are available in the documentation.\n\n**Note:** openEO strives for compatibility with [STAC](https://github.com/radiantearth/stac-spec) and [OGC WFS 3.0](https://github.com/opengeospatial/WFS_FES) as far as possible. Both standards, as well as openEO, are still under development. Therefore, it is likely that further changes and adjustments will be made in the future.",
         "tags": [
           "EO Data Discovery"
         ],
@@ -577,7 +577,7 @@
       ],
       "get": {
         "summary": "Full information about a specific EO dataset/collection.",
-        "description": "The request will ask the back-end for further details about a collections specified by the identifier `collection_name`.\n\nThis endpoint aims to be compatible with STAC and all features and extensions of [STAC](https://github.com/radiantearth/stac-spec) can be used here.\n\nMore information on [data discovery](https://open-eo.github.io/openeo-api/v/0.3.0/collections/), including common relation types for links, are available in the documentation.\n\n**Note:** openEO strives for compatibility with [STAC](https://github.com/radiantearth/stac-spec) and [OGC WFS 3.0](https://github.com/opengeospatial/WFS_FES) as far as possible. Both standards, as well as openEO, are still under development. Therefore, it is likely that further changes and adjustments will be made in the future.",
+        "description": "The request will ask the back-end for further details about a collection specified by the identifier `collection_name`.\n\nThis endpoint aims to be compatible with STAC and all features and extensions of [STAC](https://github.com/radiantearth/stac-spec) can be used here.\n\nMore information on [data discovery](https://open-eo.github.io/openeo-api/v/0.3.0/collections/), including common relation types for links, are available in the documentation.\n\n**Note:** openEO strives for compatibility with [STAC](https://github.com/radiantearth/stac-spec) and [OGC WFS 3.0](https://github.com/opengeospatial/WFS_FES) as far as possible. Both standards, as well as openEO, are still under development. Therefore, it is likely that further changes and adjustments will be made in the future.",
         "tags": [
           "EO Data Discovery"
         ],
@@ -1150,7 +1150,7 @@
                                 "type": "number"
                               },
                               "south": {
-                                "description": "Lower left corner, coordinate axis 1 (west).",
+                                "description": "Upper right corner, coordinate axis 2 (south).",
                                 "type": "number"
                               },
                               "base": {
@@ -2550,7 +2550,7 @@
                     "expires": {
                       "type": "string",
                       "format": "date-time",
-                      "description": "Time the estimate is valid for, formatted as a [RFC 3339](https://www.ietf.org/rfc/rfc3339) date-time.",
+                      "description": "Time until which the estimate is valid, formatted as a [RFC 3339](https://www.ietf.org/rfc/rfc3339) date-time.",
                       "example": "2020-11-01T00:00:00Z"
                     }
                   }
@@ -2744,7 +2744,7 @@
                       "modified": {
                         "type": "string",
                         "format": "date-time",
-                        "description": "Date and time the file has lastly been modified, formatted according to a [RFC 3339](https://www.ietf.org/rfc/rfc3339) date-time."
+                        "description": "Date and time the file has lastly been modified, formatted as a [RFC 3339](https://www.ietf.org/rfc/rfc3339) date-time."
                       }
                     },
                     "additionalProperties": true
@@ -3104,7 +3104,7 @@
       },
       "license": {
         "type": "string",
-        "description": "Collection's license(s) as a SPDX [License identifier](https://spdx.org/licenses/) or [expression](https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60) or `proprietary` if the license is not on the SPDX license list. Proprietary licensed data SHOULD add a link to the license text with the `license` relation in the links section (*not* as a value of this fields).",
+        "description": "Collection's license(s) as a SPDX [License identifier](https://spdx.org/licenses/), SPDX [expression](https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60), or the string `proprietary` if the license is not on the SPDX license list. Proprietary licensed data SHOULD add a link to the license text with the `license` relation in the links section (*not* as a value of this fields).",
         "example": "Apache-2.0"
       },
       "money": {
@@ -3379,7 +3379,7 @@
           },
           "parameters": {
             "type": "object",
-            "description": "List of arguments, i.e. the parameter names supported by the output format combined with actual values. \n\n`gis_data_type` is a special parameter only for output formats supporting multiple GIS spatial data types (e.g. raster and vector).\n\nSee `GET /output_formats` for more information, inclusing supported parameters and valid arguments.",
+            "description": "List of arguments, i.e. the parameter names supported by the output format combined with actual values. \n\n`gis_data_type` is a special parameter only for output formats supporting multiple GIS spatial data types (e.g. raster and vector).\n\nSee `GET /output_formats` for more information, including supported parameters and valid arguments.",
             "properties": {
               "gis_data_type": {
                 "$ref": "#/components/schemas/gis_data_type"

--- a/processes.json
+++ b/processes.json
@@ -43,7 +43,7 @@
               "type": "number"
             },
             "south": {
-              "description": "Lower left corner, coordinate axis 1 (west).",
+              "description": "Upper right corner, coordinate axis 2 (south).",
               "type": "number"
             },
             "base": {

--- a/subscriptions.json
+++ b/subscriptions.json
@@ -444,7 +444,7 @@
                 },
                 "temporal_extent": {
                   "type": "array",
-                  "description": "MUST be specified if the temporal extent of the dataset has changed. The temporal extent is specified by either a single timestamp or a start and an end time, each element formatted as a RFC 3339 date-time. Specifies the temporal extent of the data that has changed, not of the whole dataset. Example: The dataset covers images from beginning of 2015 until the end of 2018. A single image has been added, captured at the first day in 2019 at 01:00:00 UTC (1am). The spatial extent specified here must be an array containing a single string: `2019-01-01T01:00:00Z`.",
+                  "description": "MUST be specified if the temporal extent of the dataset has changed. The temporal extent is always specified as an array, that consists of either a single timestamp or a start and an end time, each element formatted as a RFC 3339 date-time. Specifies the temporal extent of the data that has changed, not of the whole dataset. Example: The dataset covers images from beginning of 2015 until the end of 2018. A single image has been added, captured at the first day in 2019 at 01:00:00 UTC (1am). The spatial extent specified here must be an array containing a single string: `2019-01-01T01:00:00Z`.",
                   "example": [
                     "2016-01-01T02:30:00Z",
                     "2016-01-01T04:45:00Z"
@@ -458,7 +458,7 @@
                 },
                 "spatial_extent": {
                   "type": "object",
-                  "description": "MUST be specified if the spatial extent of the dataset has changed. Specifies the spatial extent of the data that has changed, not of the whole dataset. Example: The dataset covers the whole world and an image of Austria has been added. The spatial extent specified here must be the bounding box of Austria.",
+                  "description": "MUST always be specified. It is the spatial extent of the data that was changed. Specifies the spatial extent of the data that has changed, not of the whole dataset. Example: The dataset covers the whole world and an image of Austria has been added. The spatial extent specified here must be the bounding box of Austria.",
                   "required": [
                     "west",
                     "east",
@@ -484,7 +484,7 @@
                       "type": "number"
                     },
                     "south": {
-                      "description": "Lower left corner, coordinate axis 1 (west).",
+                      "description": "Upper right corner, coordinate axis 2 (south).",
                       "type": "number"
                     },
                     "base": {


### PR DESCRIPTION
- replaced the last forgotten left/right/top/bottom with west/east/north/south
- fixed some typos
- the description for `south` was wrong a couple of times (probably copy&paste error)
- clarified some sentences
- corrected that spatial_extent must ALWAYS be specified in change notifications (so it's now consistent with the example)