### PR TITLE
Pytest based tests to check examples in openapi.json against corresponding schema

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,10 @@ install:
 - pip install pygments
 - npm install -g asyncapi-generator@0.6.7 # 0.7 only supports AsyncAPI 2.0
 - npm install -g concat-json-files
+- pip install -r tests/requirements.txt
 
 script:
+- pytest tests
 - concat-json-files "processes/*.json" -t "processes.json"
 - mv CHANGELOG.md docs/changelog.md
 - ag subscriptions.json markdown

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,10 @@ install:
 - pip install pygments
 - npm install -g asyncapi-generator@0.6.7 # 0.7 only supports AsyncAPI 2.0
 - npm install -g concat-json-files
-- pip install -r tests/requirements.txt
+- pip install -r tests/requirements.txt  # DIY example validation (PR#194)
 
 script:
-- pytest tests
+- pytest tests  # DIY example validation (PR#194)
 - concat-json-files "processes/*.json" -t "processes.json"
 - mv CHANGELOG.md docs/changelog.md
 - ag subscriptions.json markdown

--- a/openapi.json
+++ b/openapi.json
@@ -1685,66 +1685,66 @@
                         }
                       }
                     ]
-                  }
-                },
-                "example": {
-                  "PHP7": {
-                    "description": "Just an example how to reference a docker image.",
-                    "docker": "openeo/udf-php7",
-                    "default": "latest",
-                    "tags": [
-                      "latest",
-                      "7.3.1",
-                      "7.3",
-                      "7.2"
-                    ],
-                    "links": [
-                      {
-                        "href": "https://hub.docker.com/openeo/udf-php7/"
-                      }
-                    ]
                   },
-                  "R": {
-                    "description": "R programming language with Rcpp and rmarkdown.",
-                    "default": "3.5.2",
-                    "versions": {
-                      "3.1.0": {
-                        "libraries": {
-                          "Rcpp": {
-                            "version": "1.0.10",
-                            "links": [
-                              {
-                                "href": "https://cran.r-project.org/web/packages/Rcpp/index.html"
-                              }
-                            ]
-                          },
-                          "rmarkdown": {
-                            "version": 1.7,
-                            "links": [
-                              {
-                                "href": "https://cran.r-project.org/web/packages/rmarkdown/index.html"
-                              }
-                            ]
-                          }
+                  "example": {
+                    "PHP7": {
+                      "description": "Just an example how to reference a docker image.",
+                      "docker": "openeo/udf-php7",
+                      "default": "latest",
+                      "tags": [
+                        "latest",
+                        "7.3.1",
+                        "7.3",
+                        "7.2"
+                      ],
+                      "links": [
+                        {
+                          "href": "https://hub.docker.com/openeo/udf-php7/"
                         }
-                      },
-                      "3.5.2": {
-                        "libraries": {
-                          "Rcpp": {
-                            "version": "1.2.0",
-                            "links": [
-                              {
-                                "href": "https://cran.r-project.org/web/packages/Rcpp/index.html"
-                              }
-                            ]
-                          },
-                          "rmarkdown": {
-                            "version": 1.7,
-                            "links": [
-                              {
-                                "href": "https://cran.r-project.org/web/packages/rmarkdown/index.html"
-                              }
-                            ]
+                      ]
+                    },
+                    "R": {
+                      "description": "R programming language with Rcpp and rmarkdown.",
+                      "default": "3.5.2",
+                      "versions": {
+                        "3.1.0": {
+                          "libraries": {
+                            "Rcpp": {
+                              "version": "1.0.10",
+                              "links": [
+                                {
+                                  "href": "https://cran.r-project.org/web/packages/Rcpp/index.html"
+                                }
+                              ]
+                            },
+                            "rmarkdown": {
+                              "version": "1.7",
+                              "links": [
+                                {
+                                  "href": "https://cran.r-project.org/web/packages/rmarkdown/index.html"
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        "3.5.2": {
+                          "libraries": {
+                            "Rcpp": {
+                              "version": "1.2.0",
+                              "links": [
+                                {
+                                  "href": "https://cran.r-project.org/web/packages/Rcpp/index.html"
+                                }
+                              ]
+                            },
+                            "rmarkdown": {
+                              "version": "1.7",
+                              "links": [
+                                {
+                                  "href": "https://cran.r-project.org/web/packages/rmarkdown/index.html"
+                                }
+                              ]
+                            }
                           }
                         }
                       }

--- a/openapi.json
+++ b/openapi.json
@@ -1718,7 +1718,7 @@
                               ]
                             },
                             "rmarkdown": {
-                              "version": "1.7",
+                              "version": "1.7.0",
                               "links": [
                                 {
                                   "href": "https://cran.r-project.org/web/packages/rmarkdown/index.html"
@@ -1738,7 +1738,7 @@
                               ]
                             },
                             "rmarkdown": {
-                              "version": "1.7",
+                              "version": "1.7.0",
                               "links": [
                                 {
                                   "href": "https://cran.r-project.org/web/packages/rmarkdown/index.html"
@@ -4762,6 +4762,12 @@
           "example": {
             "description": "A free-form property to include an example for this argument. To represent examples that cannot be naturally represented in JSON, a string value can be used to contain the example with escaping where necessary."
           }
+        },
+        "example": {
+          "description": "A percentage between 0 and 100.",
+          "required": true,
+          "minimum": 0,
+          "maximum": 100
         }
       },
       "job_error": {

--- a/openapi.json
+++ b/openapi.json
@@ -4762,15 +4762,6 @@
           "example": {
             "description": "A free-form property to include an example for this argument. To represent examples that cannot be naturally represented in JSON, a string value can be used to contain the example with escaping where necessary."
           }
-        },
-        "example": {
-          "format": "GTiff",
-          "parameters": {
-            "tiles": true,
-            "compress": "jpeg",
-            "photometric": "YCBCR",
-            "jpeg_quality": 80
-          }
         }
       },
       "job_error": {

--- a/openapi.json
+++ b/openapi.json
@@ -1156,7 +1156,7 @@
                       }
                     ],
                     "properties": {
-                      "cube:properties": {
+                      "cube:dimensions": {
                         "x": {
                           "type": "spatial",
                           "axis": "x",
@@ -3291,7 +3291,7 @@
                         "modified": "2018-01-03T10:55:29Z"
                       }
                     ],
-                    "links": {}
+                    "links": []
                   }
                 }
               }

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,3 @@
+pytest
+jsonschema
+py-openapi-schema-to-json-schema

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,3 +1,11 @@
+"""
+
+DIY validation of openapi.json examples against their corresponding schema (PR#194).
+Currently implemented as pytest based test suite due to lack of this
+validation feature in speccy itself (see https://github.com/wework/speccy/issues/287)
+
+"""
+
 import json
 from pathlib import Path
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,79 @@
+import json
+from pathlib import Path
+
+import _pytest
+import jsonschema
+import openapi_schema_to_json_schema
+import pytest
+
+_PROJECT_ROOT = Path(__file__).parent.parent
+
+
+def get_api_spec() -> dict:
+    with (_PROJECT_ROOT / 'openapi.json').open() as f:
+        return json.load(f)
+
+
+class OpenApiValidator:
+    """
+    Helper class to validate OpenApi specifications
+
+    Implemented using combination of `jsonschema` and `openapi_schema_to_json_schema`
+    due to current lack of a dedicated OpenApi validation module
+    """
+
+    class OpenApiResolver(jsonschema.RefResolver):
+        """Custom resolver for OpenApi $ref references"""
+
+        def resolve(self, ref):
+            url, schema = super().resolve(ref)
+            return url, openapi_schema_to_json_schema.to_json_schema(schema)
+
+    def __init__(self, api_spec: dict, schema: dict, resolver_cls=OpenApiResolver):
+        resolver = resolver_cls.from_schema(
+            schema=openapi_schema_to_json_schema.to_json_schema(api_spec)
+        )
+        # OpenApi 3 is closest to JSON Schema Draft 4
+        self.validator = jsonschema.Draft4Validator(
+            schema=openapi_schema_to_json_schema.to_json_schema(schema),
+            resolver=resolver
+        )
+
+    def validate(self, instance):
+        return self.validator.validate(instance)
+
+
+def pytest_generate_tests(metafunc: _pytest.python.Metafunc):
+    """
+    Pytest hook for custom test parametrization
+    """
+    if 'schema_with_example' in metafunc.fixturenames:
+
+        def extract_schemas_with_example(d: dict, path: tuple = ()):
+            """Extract all nodes in the spec that have an 'example' item."""
+            for key, value in d.items():
+                if isinstance(value, dict):
+                    if 'example' in value:
+                        yield path + (key,), value
+                    else:
+                        yield from extract_schemas_with_example(value, path + (key,))
+
+        api_spec = get_api_spec()
+        schemas = list(extract_schemas_with_example(api_spec))
+        metafunc.parametrize(
+            ['api_spec', 'path', 'schema_with_example'],
+            [(api_spec, path, schema) for path, schema in schemas],
+            ids=[':'.join(path) for path, schema in schemas]
+        )
+
+
+def test_schema_example(api_spec, path, schema_with_example):
+    """
+    Check whether examples included in the API schemas correspond with the schema.
+    """
+    if path[-1] == "properties":
+        pytest.skip("This is probably not a schema example but an 'example' property")
+    assert "type" in schema_with_example
+    assert "example" in schema_with_example
+    example = schema_with_example['example']
+    OpenApiValidator(api_spec=api_spec, schema=schema_with_example).validate(example)


### PR DESCRIPTION
inspired by #193:
- I created pytest based test suite ("suite" is big word for a single but parametrized test function) that checks all the examples in openapi.json against their corresponding schema
- found a couple of issues and fixed them
- added pytest run to travis