### PR TITLE
STAC for job results (#131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The default type for Process Graph Variables is not `string`, but no specific (any) data type. Default values can be of any type.
 - Official support for [CommonMark 0.29 instead of CommonMark 0.28](https://spec.commonmark.org/0.29/changes.html). [#203](https://github.com/Open-EO/openeo-api/issues/203)
 - `GET /collections/{collectionId}`: Band names are required.
-- `GET /jobs/{job_id}/results`: Response body has changed to be a valid STAC Item, response is sent as content type `application/geo+json`.
+- `GET /jobs/{job_id}/results`: Response body has changed to be a valid STAC Item, allows content type `application/geo+json`.
 
 ### Removed
 - `GET /jobs/{job_id}/results`: `Expires` header has been removed, use `expires` property in the response body instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - If `currency` returned by `GET /` is null, `costs` and `budget` are unsupported. `costs` and `budget` fields in various endpoints can be set to null (default).
 - The default type for Process Graph Variables is not string, but any data type. Default values can be of any type.
 - Official support for [CommonMark 0.29 instead of CommonMark 0.28](https://spec.commonmark.org/0.29/changes.html). [#203](https://github.com/Open-EO/openeo-api/issues/203)
+- `GET /jobs/{job_id}/results`: Response body has changed to be a valid STAC Item.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Unsupported endpoints are not forced to return a `FeatureUnsupported` (501) error and can return a simple `NotFound` (404) instead.
-- `GET /collections/{collectionId}`: Band names are required.
-- If `currency` returned by `GET /` is null, `costs` and `budget` are unsupported. `costs` and `budget` fields in various endpoints can be set to null (default).
-- The default type for Process Graph Variables is not string, but any data type. Default values can be of any type.
+- If `currency` returned by `GET /` is `null`, `costs` and `budget` are unsupported. `costs` and `budget` fields in various endpoints can be set to `null` (default).
+- The default type for Process Graph Variables is not `string`, but no specific (any) data type. Default values can be of any type.
 - Official support for [CommonMark 0.29 instead of CommonMark 0.28](https://spec.commonmark.org/0.29/changes.html). [#203](https://github.com/Open-EO/openeo-api/issues/203)
-- `GET /jobs/{job_id}/results`: Response body has changed to be a valid STAC Item.
+- `GET /collections/{collectionId}`: Band names are required.
+- `GET /jobs/{job_id}/results`: Response body has changed to be a valid STAC Item, response is sent as content type `application/geo+json`.
+
+### Removed
+- `GET /jobs/{job_id}/results`: `Expires` header has been removed, use `expires` property in the response body instead.
 
 ### Fixed
 

--- a/openapi.json
+++ b/openapi.json
@@ -3095,7 +3095,7 @@
       ],
       "get": {
         "summary": "Download results for a completed batch job",
-        "description": "After finishing processing, this request will provide signed URLs to the processed files of the batch job.\n\nTitle, description and the date and time of the last update from the job SHOULD be included in the response.\n\nURL signing is a way to protect files from unauthorized access with a key instead of HTTP header based authorization. The URL signing key is similar to a password and it's inclusion in the URL allows to download files using simple GET requests supported by a wide range of programs, e.g. web browsers or download managers. Back-ends are responsible to generate the URL signing keys and their appropriate expiration. The back-end MAY indicate an expiration time by sending an `Expires` header.\n\nIf processing has not finished yet requests to this endpoint MUST be rejected with openEO error `JobNotFinished`.\n\nA header named `OpenEO-Costs` MAY be sent with all responses to indicate the costs for downloading the data.",
+        "description": "After finishing processing, this request will provide signed URLs to the processed files of the batch job with some additional metadata. The response is a valid [STAC Item](https://github.com/radiantearth/stac-spec/tree/master/item-spec).\n\nURL signing is a way to protect files from unauthorized access with a key in the URL instead of HTTP header based authorization. The URL signing key is similar to a password and its inclusion in the URL allows to download files using simple GET requests supported by a wide range of programs, e.g. web browsers or download managers. Back-ends are responsible to generate the URL signing keys and to manage their appropriate expiration. The back-end MAY indicate an expiration time by setting the `expires` property.\n\nIf processing has not finished yet requests to this endpoint MUST be rejected with openEO error `JobNotFinished`.",
         "tags": [
           "Batch Job Management"
         ],
@@ -3108,13 +3108,6 @@
           "200": {
             "description": "Valid download links have been returned. The download links doesn't necessarily need to be located under the API base url.",
             "headers": {
-              "Expires": {
-                "description": "Indicates the expiration time of the signed URLs contained in this document. Needs to follow the specification at https://tools.ietf.org/html/rfc2616#section-14.21",
-                "schema": {
-                  "type": "string",
-                  "example": "Wed, 21 Oct 2018 07:28:00 GMT"
-                }
-              },
               "OpenEO-Costs": {
                 "description": "Specifies the costs for fully downloading the data **once**, i.e. this header MAY change in subsequent calls. It MUST be set to `0` if the requester is the owner of the job and still has free downloads included in his processing charges estimated by `GET /jobs/{job_id}/estimate`.\n If a requester other than the owner is requesting the data of a shared job this header indicates the costs for the requester.",
                 "schema": {
@@ -3198,12 +3191,34 @@
                       "properties": {
                         "datetime": {
                           "title": "Date and Time",
-                          "description": "The searchable date/time of the assets, in UTC.",
+                          "description": "The searchable date/time of the data, in UTC. For timeseries: The first or start date and time for the data. Formatted as a [RFC 3339](https://www.ietf.org/rfc/rfc3339) date-time.",
                           "type": "string",
                           "format": "date-time"
                         },
+                        "dtr:start_datetime": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "For timeseries: The first or start date and time for the data, in UTC. Formatted as a [RFC 3339](https://www.ietf.org/rfc/rfc3339) date-time."
+                        },
+                        "dtr:end_datetime": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "For timeseries: The last or end date and time for the data, in UTC. Formatted as a [RFC 3339](https://www.ietf.org/rfc/rfc3339) date-time."
+                        },
                         "title": {
                           "$ref": "#/components/schemas/title"
+                        },
+                        "description": {
+                          "$ref": "#/components/schemas/description"
+                        },
+                        "updated": {
+                          "$ref": "#/components/schemas/updated"
+                        },
+                        "expires": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Time until which the assets are accessible, in UTC. Formatted as a [RFC 3339](https://www.ietf.org/rfc/rfc3339) date-time.",
+                          "example": "2020-11-01T00:00:00Z"
                         }
                       }
                     },
@@ -3244,49 +3259,10 @@
                     },
                     "links": {
                       "type": "array",
-                      "description": "List of related URLs.",
+                      "description": "List of related URLs. This MUST NOT be the processed and downloadable data, specify it in the `assets` property instead.",
                       "items": {
                         "$ref": "#/components/schemas/link"
                       }
-                    }
-                  }
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "title": "Batch Job Results Response as simple JSON",
-                  "type": "object",
-                  "required": [
-                    "links"
-                  ],
-                  "properties": {
-                    "id": {
-                      "$ref": "#/components/schemas/job_id"
-                    },
-                    "title": {
-                      "$ref": "#/components/schemas/title"
-                    },
-                    "description": {
-                      "$ref": "#/components/schemas/description"
-                    },
-                    "updated": {
-                      "$ref": "#/components/schemas/updated"
-                    },
-                    "links": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/link"
-                      },
-                      "example": [
-                        {
-                          "href": "https://openeo.org/api/download/583fba8b2ce583fba8b2ce/1.tif",
-                          "type": "image/tiff; application=geotiff"
-                        },
-                        {
-                          "href": "https://openeo.org/api/download/583fba8b2ce583fba8b2ce/2.tif",
-                          "type": "image/tiff; application=geotiff"
-                        }
-                      ]
                     }
                   }
                 }

--- a/openapi.json
+++ b/openapi.json
@@ -3154,29 +3154,10 @@
                       "$ref": "#/components/schemas/bbox"
                     },
                     "geometry": {
-                      "title": "GeoJSON Geometry",
                       "description": "Defines the full footprint of the asset represented by this item as GeoJSON Geometry.",
-                      "oneOf": [
+                      "allOf": [
                         {
-                          "$ref": "#/components/schemas/GeoJsonPoint"
-                        },
-                        {
-                          "$ref": "#/components/schemas/GeoJsonLineString"
-                        },
-                        {
-                          "$ref": "#/components/schemas/GeoJsonPolygon"
-                        },
-                        {
-                          "$ref": "#/components/schemas/GeoJsonMultiPoint"
-                        },
-                        {
-                          "$ref": "#/components/schemas/GeoJsonMultiLineString"
-                        },
-                        {
-                          "$ref": "#/components/schemas/GeoJsonMultiPolygon"
-                        },
-                        {
-                          "$ref": "#/components/schemas/GeoJsonGeometryCollection"
+                          "$ref": "#/components/schemas/GeoJsonGeometry"
                         }
                       ],
                       "example": {
@@ -3252,12 +3233,12 @@
                       },
                       "example": {
                         "1": {
-                          "href": "https://openeo.org/api/v0.4/download/583fba8b2ce/1.tif",
-                          "type": "image/tiff"
+                          "href": "https://openeo.org/api/download/583fba8b2ce583fba8b2ce/1.tif",
+                          "type": "image/tiff; application=geotiff"
                         },
                         "2": {
-                          "href": "https://openeo.org/api/v0.4/download/583fba8b2ce/2.tif",
-                          "type": "image/tiff"
+                          "href": "https://openeo.org/api/download/583fba8b2ce583fba8b2ce/2.tif",
+                          "type": "image/tiff; application=geotiff"
                         }
                       }
                     },
@@ -3298,12 +3279,12 @@
                       },
                       "example": [
                         {
-                          "href": "https://openeo.org/api/v0.4/download/583fba8b2ce/1.tif",
-                          "type": "image/tiff"
+                          "href": "https://openeo.org/api/download/583fba8b2ce583fba8b2ce/1.tif",
+                          "type": "image/tiff; application=geotiff"
                         },
                         {
-                          "href": "https://openeo.org/api/v0.4/download/583fba8b2ce/2.tif",
-                          "type": "image/tiff"
+                          "href": "https://openeo.org/api/download/583fba8b2ce583fba8b2ce/2.tif",
+                          "type": "image/tiff; application=geotiff"
                         }
                       ]
                     }
@@ -5034,30 +5015,6 @@
           90
         ]
       },
-      "GeoJsonGeometry": {
-        "type": "object",
-        "title": "GeoJSON Geometry",
-        "discriminator": {
-          "propertyName": "type"
-        },
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "Point",
-              "LineString",
-              "Polygon",
-              "MultiPoint",
-              "MultiLineString",
-              "MultiPolygon"
-            ],
-            "description": "the geometry type"
-          }
-        }
-      },
       "GeoJsonPoint3D": {
         "type": "array",
         "description": "Point in 3D space",
@@ -5070,70 +5027,161 @@
       "GeoJsonPoint": {
         "type": "object",
         "title": "GeoJSON Point",
-        "allOf": [
+        "required": [
+          "type",
+          "coordinates"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "Point"
+            ]
+          },
+          "coordinates": {
+            "$ref": "#/components/schemas/GeoJsonPoint3D"
+          }
+        }
+      },
+      "GeoJsonGeometry": {
+        "title": "GeoJSON Geometry",
+        "oneOf": [
           {
-            "$ref": "#/components/schemas/GeoJsonGeometry"
+            "$ref": "#/components/schemas/GeoJsonPoint"
           },
           {
-            "properties": {
-              "coordinates": {
-                "$ref": "#/components/schemas/GeoJsonPoint3D"
-              }
-            }
+            "$ref": "#/components/schemas/GeoJsonLineString"
+          },
+          {
+            "$ref": "#/components/schemas/GeoJsonPolygon"
+          },
+          {
+            "$ref": "#/components/schemas/GeoJsonMultiPoint"
+          },
+          {
+            "$ref": "#/components/schemas/GeoJsonMultiLineString"
+          },
+          {
+            "$ref": "#/components/schemas/GeoJsonMultiPolygon"
+          },
+          {
+            "$ref": "#/components/schemas/GeoJsonGeometryCollection"
           }
         ]
       },
       "GeoJsonLineString": {
         "type": "object",
         "title": "GeoJSON LineString",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/GeoJsonGeometry"
+        "required": [
+          "type",
+          "coordinates"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "LineString"
+            ]
           },
-          {
-            "properties": {
-              "coordinates": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/GeoJsonPoint3D"
-                }
-              }
+          "coordinates": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GeoJsonPoint3D"
             }
           }
-        ]
+        }
       },
       "GeoJsonPolygon": {
         "type": "object",
         "title": "GeoJSON Polygon",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/GeoJsonGeometry"
+        "required": [
+          "type",
+          "coordinates"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "Polygon"
+            ]
           },
-          {
-            "properties": {
-              "coordinates": {
-                "type": "array",
-                "items": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/GeoJsonPoint3D"
-                  }
-                }
+          "coordinates": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/GeoJsonPoint3D"
               }
             }
           }
-        ]
+        }
       },
       "GeoJsonMultiPoint": {
         "type": "object",
         "title": "GeoJSON MultiPoint",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/GeoJsonGeometry"
+        "required": [
+          "type",
+          "coordinates"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "MultiPoint"
+            ]
           },
-          {
-            "properties": {
-              "coordinates": {
+          "coordinates": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GeoJsonPoint3D"
+            }
+          }
+        }
+      },
+      "GeoJsonMultiLineString": {
+        "type": "object",
+        "title": "GeoJSON MultiLineString",
+        "required": [
+          "type",
+          "coordinates"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "MultiLineString"
+            ]
+          },
+          "coordinates": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/GeoJsonPoint3D"
+              }
+            }
+          }
+        }
+      },
+      "GeoJsonMultiPolygon": {
+        "type": "object",
+        "title": "GeoJSON MultiPolygon",
+        "required": [
+          "type",
+          "coordinates"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "MultiPolygon"
+            ]
+          },
+          "coordinates": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
                 "type": "array",
                 "items": {
                   "$ref": "#/components/schemas/GeoJsonPoint3D"
@@ -5141,54 +5189,7 @@
               }
             }
           }
-        ]
-      },
-      "GeoJsonMultiLineString": {
-        "type": "object",
-        "title": "GeoJSON MultiLineString",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/GeoJsonGeometry"
-          },
-          {
-            "properties": {
-              "coordinates": {
-                "type": "array",
-                "items": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/GeoJsonPoint3D"
-                  }
-                }
-              }
-            }
-          }
-        ]
-      },
-      "GeoJsonMultiPolygon": {
-        "type": "object",
-        "title": "GeoJSON MultiPolygon",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/GeoJsonGeometry"
-          },
-          {
-            "properties": {
-              "coordinates": {
-                "type": "array",
-                "items": {
-                  "type": "array",
-                  "items": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/GeoJsonPoint3D"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        ]
+        }
       },
       "GeoJsonGeometryCollection": {
         "type": "object",

--- a/openapi.json
+++ b/openapi.json
@@ -3116,155 +3116,14 @@
               }
             },
             "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/job_result_stac"
+                }
+              },
               "application/geo+json": {
                 "schema": {
-                  "title": "Batch Job Results Response as STAC Item",
-                  "type": "object",
-                  "required": [
-                    "stac_version",
-                    "id",
-                    "type",
-                    "bbox",
-                    "geometry",
-                    "properties",
-                    "assets",
-                    "links"
-                  ],
-                  "properties": {
-                    "stac_version": {
-                      "$ref": "#/components/schemas/stac_version"
-                    },
-                    "id": {
-                      "$ref": "#/components/schemas/job_id"
-                    },
-                    "type": {
-                      "type": "string",
-                      "enum": [
-                        "Feature"
-                      ]
-                    },
-                    "bbox": {
-                      "$ref": "#/components/schemas/bbox"
-                    },
-                    "geometry": {
-                      "description": "Defines the full footprint of the asset represented by this item as GeoJSON Geometry.",
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/GeoJsonGeometry"
-                        }
-                      ],
-                      "example": {
-                        "type": "Polygon",
-                        "coordinates": [
-                          [
-                            [
-                              -180,
-                              -90
-                            ],
-                            [
-                              180,
-                              -90
-                            ],
-                            [
-                              180,
-                              90
-                            ],
-                            [
-                              -180,
-                              90
-                            ],
-                            [
-                              -180,
-                              -90
-                            ]
-                          ]
-                        ]
-                      }
-                    },
-                    "properties": {
-                      "type": "object",
-                      "title": "Item Properties",
-                      "description": "MAY contain any additional properties, e.g. other STAC Item properties, properties from STAC extensions or custom properties.",
-                      "required": [
-                        "datetime"
-                      ],
-                      "properties": {
-                        "datetime": {
-                          "title": "Date and Time",
-                          "description": "The searchable date/time of the data, in UTC. For timeseries: The first or start date and time for the data. Formatted as a [RFC 3339](https://www.ietf.org/rfc/rfc3339) date-time.",
-                          "type": "string",
-                          "format": "date-time"
-                        },
-                        "dtr:start_datetime": {
-                          "type": "string",
-                          "format": "date-time",
-                          "description": "For timeseries: The first or start date and time for the data, in UTC. Formatted as a [RFC 3339](https://www.ietf.org/rfc/rfc3339) date-time."
-                        },
-                        "dtr:end_datetime": {
-                          "type": "string",
-                          "format": "date-time",
-                          "description": "For timeseries: The last or end date and time for the data, in UTC. Formatted as a [RFC 3339](https://www.ietf.org/rfc/rfc3339) date-time."
-                        },
-                        "title": {
-                          "$ref": "#/components/schemas/title"
-                        },
-                        "description": {
-                          "$ref": "#/components/schemas/description"
-                        },
-                        "updated": {
-                          "$ref": "#/components/schemas/updated"
-                        },
-                        "expires": {
-                          "type": "string",
-                          "format": "date-time",
-                          "description": "Time until which the assets are accessible, in UTC. Formatted as a [RFC 3339](https://www.ietf.org/rfc/rfc3339) date-time.",
-                          "example": "2020-11-01T00:00:00Z"
-                        }
-                      }
-                    },
-                    "assets": {
-                      "type": "object",
-                      "title": "Item Assets",
-                      "description": "Dictionary of asset objects that can be downloaded, each with a unique key.",
-                      "additionalProperties": {
-                        "type": "object",
-                        "required": [
-                          "href"
-                        ],
-                        "properties": {
-                          "href": {
-                            "title": "Signed URL to the downloadable asset.",
-                            "type": "string"
-                          },
-                          "title": {
-                            "title": "The displayed title for clients and users.",
-                            "type": "string"
-                          },
-                          "type": {
-                            "title": "Media type of the asset.",
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "example": {
-                        "1": {
-                          "href": "https://openeo.org/api/download/583fba8b2ce583fba8b2ce/1.tif",
-                          "type": "image/tiff; application=geotiff"
-                        },
-                        "2": {
-                          "href": "https://openeo.org/api/download/583fba8b2ce583fba8b2ce/2.tif",
-                          "type": "image/tiff; application=geotiff"
-                        }
-                      }
-                    },
-                    "links": {
-                      "type": "array",
-                      "description": "List of related URLs. This MUST NOT be the processed and downloadable data, specify it in the `assets` property instead.",
-                      "items": {
-                        "$ref": "#/components/schemas/link"
-                      }
-                    }
-                  }
+                  "$ref": "#/components/schemas/job_result_stac"
                 }
               }
             }
@@ -3706,6 +3565,155 @@
   },
   "components": {
     "schemas": {
+      "job_result_stac": {
+        "title": "Batch Job Results Response as STAC Item",
+        "type": "object",
+        "required": [
+          "stac_version",
+          "id",
+          "type",
+          "bbox",
+          "geometry",
+          "properties",
+          "assets",
+          "links"
+        ],
+        "properties": {
+          "stac_version": {
+            "$ref": "#/components/schemas/stac_version"
+          },
+          "id": {
+            "$ref": "#/components/schemas/job_id"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "Feature"
+            ]
+          },
+          "bbox": {
+            "$ref": "#/components/schemas/bbox"
+          },
+          "geometry": {
+            "description": "Defines the full footprint of the asset represented by this item as GeoJSON Geometry.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GeoJsonGeometry"
+              }
+            ],
+            "example": {
+              "type": "Polygon",
+              "coordinates": [
+                [
+                  [
+                    -180,
+                    -90
+                  ],
+                  [
+                    180,
+                    -90
+                  ],
+                  [
+                    180,
+                    90
+                  ],
+                  [
+                    -180,
+                    90
+                  ],
+                  [
+                    -180,
+                    -90
+                  ]
+                ]
+              ]
+            }
+          },
+          "properties": {
+            "type": "object",
+            "title": "Item Properties",
+            "description": "MAY contain any additional properties, e.g. other STAC Item properties, properties from STAC extensions or custom properties.",
+            "required": [
+              "datetime"
+            ],
+            "properties": {
+              "datetime": {
+                "title": "Date and Time",
+                "description": "The searchable date/time of the data, in UTC. For timeseries: The first or start date and time for the data. Formatted as a [RFC 3339](https://www.ietf.org/rfc/rfc3339) date-time.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "dtr:start_datetime": {
+                "type": "string",
+                "format": "date-time",
+                "description": "For timeseries: The first or start date and time for the data, in UTC. Formatted as a [RFC 3339](https://www.ietf.org/rfc/rfc3339) date-time."
+              },
+              "dtr:end_datetime": {
+                "type": "string",
+                "format": "date-time",
+                "description": "For timeseries: The last or end date and time for the data, in UTC. Formatted as a [RFC 3339](https://www.ietf.org/rfc/rfc3339) date-time."
+              },
+              "title": {
+                "$ref": "#/components/schemas/title"
+              },
+              "description": {
+                "$ref": "#/components/schemas/description"
+              },
+              "updated": {
+                "$ref": "#/components/schemas/updated"
+              },
+              "expires": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Time until which the assets are accessible, in UTC. Formatted as a [RFC 3339](https://www.ietf.org/rfc/rfc3339) date-time.",
+                "example": "2020-11-01T00:00:00Z"
+              }
+            }
+          },
+          "assets": {
+            "type": "object",
+            "title": "Item Assets",
+            "description": "Dictionary of asset objects that can be downloaded, each with a unique key.",
+            "additionalProperties": {
+              "type": "object",
+              "required": [
+                "href"
+              ],
+              "properties": {
+                "href": {
+                  "title": "Signed URL to the downloadable asset.",
+                  "type": "string"
+                },
+                "title": {
+                  "title": "The displayed title for clients and users.",
+                  "type": "string"
+                },
+                "type": {
+                  "title": "Media type of the asset.",
+                  "type": "string"
+                }
+              }
+            },
+            "example": {
+              "1": {
+                "href": "https://openeo.org/api/download/583fba8b2ce583fba8b2ce/1.tif",
+                "type": "image/tiff; application=geotiff"
+              },
+              "2": {
+                "href": "https://openeo.org/api/download/583fba8b2ce583fba8b2ce/2.tif",
+                "type": "image/tiff; application=geotiff"
+              }
+            }
+          },
+          "links": {
+            "type": "array",
+            "description": "List of related URLs. This MUST NOT be the processed and downloadable data, specify it in the `assets` property instead.",
+            "items": {
+              "$ref": "#/components/schemas/link"
+            }
+          }
+        }
+      },
       "production": {
         "type": "boolean",
         "description": "Specifies whether the implementation is ready to be used in production use (`true`) or not (`false`).\nClients SHOULD only connect to non-production implementations if the user explicetly confirmed to use a non-production implementation.",

--- a/openapi.json
+++ b/openapi.json
@@ -3171,7 +3171,7 @@
       ],
       "get": {
         "summary": "Download results for a completed batch job",
-        "description": "After finishing processing, this request will provide signed URLs to the processed files of the batch job with some additional metadata. The response is a valid [STAC Item](https://github.com/radiantearth/stac-spec/tree/master/item-spec).\n\nURL signing is a way to protect files from unauthorized access with a key in the URL instead of HTTP header based authorization. The URL signing key is similar to a password and its inclusion in the URL allows to download files using simple GET requests supported by a wide range of programs, e.g. web browsers or download managers. Back-ends are responsible to generate the URL signing keys and to manage their appropriate expiration. The back-end MAY indicate an expiration time by setting the `expires` property.\n\nIf processing has not finished yet requests to this endpoint MUST be rejected with openEO error `JobNotFinished`.",
+        "description": "After finishing processing, this request will provide signed URLs to the processed files of the batch job with some additional metadata. The response is a [STAC Item (version 0.6.2)](https://github.com/radiantearth/stac-spec/tree/master/item-spec) if it has spatial and temporal references.\n\nURL signing is a way to protect files from unauthorized access with a key in the URL instead of HTTP header based authorization. The URL signing key is similar to a password and its inclusion in the URL allows to download files using simple GET requests supported by a wide range of programs, e.g. web browsers or download managers. Back-ends are responsible to generate the URL signing keys and to manage their appropriate expiration. The back-end MAY indicate an expiration time by setting the `expires` property.\n\nIf processing has not finished yet requests to this endpoint MUST be rejected with openEO error `JobNotFinished`.",
         "tags": [
           "Batch Job Management"
         ],
@@ -3194,12 +3194,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/job_result_stac"
+                  "$ref": "#/components/schemas/job_result"
                 }
               },
               "application/geo+json": {
                 "schema": {
-                  "$ref": "#/components/schemas/job_result_stac"
+                  "$ref": "#/components/schemas/job_result"
                 }
               }
             }
@@ -3641,7 +3641,7 @@
   },
   "components": {
     "schemas": {
-      "job_result_stac": {
+      "job_result": {
         "title": "Batch Job Results Response as STAC Item",
         "type": "object",
         "required": [
@@ -3715,9 +3715,10 @@
             "properties": {
               "datetime": {
                 "title": "Date and Time",
-                "description": "The searchable date/time of the data, in UTC. For timeseries: The first or start date and time for the data. Formatted as a [RFC 3339](https://www.ietf.org/rfc/rfc3339) date-time.",
+                "description": "The searchable date/time of the data, in UTC. Formatted as a [RFC 3339](https://www.ietf.org/rfc/rfc3339) date-time. For timeseries: The center date and time for the data.\n\nIt is NOT RECOMMENDED to set this field to `null` as this field is required in a STAC Item.",
                 "type": "string",
-                "format": "date-time"
+                "format": "date-time",
+                "nullable": true
               },
               "dtr:start_datetime": {
                 "type": "string",

--- a/openapi.json
+++ b/openapi.json
@@ -3123,9 +3123,157 @@
               }
             },
             "content": {
+              "application/geo+json": {
+                "schema": {
+                  "title": "Batch Job Results Response as STAC Item",
+                  "type": "object",
+                  "required": [
+                    "stac_version",
+                    "id",
+                    "type",
+                    "bbox",
+                    "geometry",
+                    "properties",
+                    "assets",
+                    "links"
+                  ],
+                  "properties": {
+                    "stac_version": {
+                      "$ref": "#/components/schemas/stac_version"
+                    },
+                    "id": {
+                      "$ref": "#/components/schemas/job_id"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "Feature"
+                      ]
+                    },
+                    "bbox": {
+                      "$ref": "#/components/schemas/bbox"
+                    },
+                    "geometry": {
+                      "title": "GeoJSON Geometry",
+                      "description": "Defines the full footprint of the asset represented by this item as GeoJSON Geometry.",
+                      "oneOf": [
+                        {
+                          "$ref": "#/components/schemas/GeoJsonPoint"
+                        },
+                        {
+                          "$ref": "#/components/schemas/GeoJsonLineString"
+                        },
+                        {
+                          "$ref": "#/components/schemas/GeoJsonPolygon"
+                        },
+                        {
+                          "$ref": "#/components/schemas/GeoJsonMultiPoint"
+                        },
+                        {
+                          "$ref": "#/components/schemas/GeoJsonMultiLineString"
+                        },
+                        {
+                          "$ref": "#/components/schemas/GeoJsonMultiPolygon"
+                        },
+                        {
+                          "$ref": "#/components/schemas/GeoJsonGeometryCollection"
+                        }
+                      ],
+                      "example": {
+                        "type": "Polygon",
+                        "coordinates": [
+                          [
+                            [
+                              -180,
+                              -90
+                            ],
+                            [
+                              180,
+                              -90
+                            ],
+                            [
+                              180,
+                              90
+                            ],
+                            [
+                              -180,
+                              90
+                            ],
+                            [
+                              -180,
+                              -90
+                            ]
+                          ]
+                        ]
+                      }
+                    },
+                    "properties": {
+                      "type": "object",
+                      "title": "Item Properties",
+                      "description": "MAY contain any additional properties, e.g. other STAC Item properties, properties from STAC extensions or custom properties.",
+                      "required": [
+                        "datetime"
+                      ],
+                      "properties": {
+                        "datetime": {
+                          "title": "Date and Time",
+                          "description": "The searchable date/time of the assets, in UTC.",
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "title": {
+                          "$ref": "#/components/schemas/title"
+                        }
+                      }
+                    },
+                    "assets": {
+                      "type": "object",
+                      "title": "Item Assets",
+                      "description": "Dictionary of asset objects that can be downloaded, each with a unique key.",
+                      "additionalProperties": {
+                        "type": "object",
+                        "required": [
+                          "href"
+                        ],
+                        "properties": {
+                          "href": {
+                            "title": "Signed URL to the downloadable asset.",
+                            "type": "string"
+                          },
+                          "title": {
+                            "title": "The displayed title for clients and users.",
+                            "type": "string"
+                          },
+                          "type": {
+                            "title": "Media type of the asset.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "example": {
+                        "1": {
+                          "href": "https://openeo.org/api/v0.4/download/583fba8b2ce/1.tif",
+                          "type": "image/tiff"
+                        },
+                        "2": {
+                          "href": "https://openeo.org/api/v0.4/download/583fba8b2ce/2.tif",
+                          "type": "image/tiff"
+                        }
+                      }
+                    },
+                    "links": {
+                      "type": "array",
+                      "description": "List of related URLs.",
+                      "items": {
+                        "$ref": "#/components/schemas/link"
+                      }
+                    }
+                  }
+                }
+              },
               "application/json": {
                 "schema": {
-                  "title": "Batch Job Results Response",
+                  "title": "Batch Job Results Response as simple JSON",
                   "type": "object",
                   "required": [
                     "links"
@@ -3995,19 +4143,7 @@
         ],
         "properties": {
           "spatial": {
-            "description": "Potential *spatial extent* covered by the collection. The bounding box is provided as four or six numbers, depending on whether the coordinate reference system includes a vertical axis (height or depth):\n\n- West (lower left corner, coordinate axis 1)\n- South (lower left corner, coordinate axis 2)\n- Base (optional, lower left corner, coordinate axis 3)\n- East (upper right corner, coordinate axis 1)\n- North (upper right corner, coordinate axis 2)\n- Height (optional, upper right corner, coordinate axis 3)\n\nThe coordinate reference system of the values is WGS84 longitude/latitude.",
-            "type": "array",
-            "minItems": 4,
-            "maxItems": 6,
-            "items": {
-              "type": "number"
-            },
-            "example": [
-              -180,
-              -90,
-              180,
-              90
-            ]
+            "$ref": "#/components/schemas/bbox"
           },
           "temporal": {
             "type": "array",
@@ -4880,6 +5016,199 @@
             "format": "date-time",
             "description": "Date and time the file has lastly been modified, formatted as a [RFC 3339](https://www.ietf.org/rfc/rfc3339) date-time.",
             "example": "2018-01-03T10:55:29Z"
+          }
+        }
+      },
+      "bbox": {
+        "description": "Potential *spatial extent* covered by the data. The bounding box is provided as four or six numbers, depending on whether the coordinate reference system includes a vertical axis (height or depth):\n\n- West (lower left corner, coordinate axis 1)\n- South (lower left corner, coordinate axis 2)\n- Base (optional, lower left corner, coordinate axis 3)\n- East (upper right corner, coordinate axis 1)\n- North (upper right corner, coordinate axis 2)\n- Height (optional, upper right corner, coordinate axis 3)\n\nThe coordinate reference system of the values is WGS84 longitude/latitude.",
+        "type": "array",
+        "minItems": 4,
+        "maxItems": 6,
+        "items": {
+          "type": "number"
+        },
+        "example": [
+          -180,
+          -90,
+          180,
+          90
+        ]
+      },
+      "GeoJsonGeometry": {
+        "type": "object",
+        "title": "GeoJSON Geometry",
+        "discriminator": {
+          "propertyName": "type"
+        },
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "Point",
+              "LineString",
+              "Polygon",
+              "MultiPoint",
+              "MultiLineString",
+              "MultiPolygon"
+            ],
+            "description": "the geometry type"
+          }
+        }
+      },
+      "GeoJsonPoint3D": {
+        "type": "array",
+        "description": "Point in 3D space",
+        "minItems": 2,
+        "maxItems": 3,
+        "items": {
+          "type": "number"
+        }
+      },
+      "GeoJsonPoint": {
+        "type": "object",
+        "title": "GeoJSON Point",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/GeoJsonGeometry"
+          },
+          {
+            "properties": {
+              "coordinates": {
+                "$ref": "#/components/schemas/GeoJsonPoint3D"
+              }
+            }
+          }
+        ]
+      },
+      "GeoJsonLineString": {
+        "type": "object",
+        "title": "GeoJSON LineString",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/GeoJsonGeometry"
+          },
+          {
+            "properties": {
+              "coordinates": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/GeoJsonPoint3D"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "GeoJsonPolygon": {
+        "type": "object",
+        "title": "GeoJSON Polygon",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/GeoJsonGeometry"
+          },
+          {
+            "properties": {
+              "coordinates": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/GeoJsonPoint3D"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "GeoJsonMultiPoint": {
+        "type": "object",
+        "title": "GeoJSON MultiPoint",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/GeoJsonGeometry"
+          },
+          {
+            "properties": {
+              "coordinates": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/GeoJsonPoint3D"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "GeoJsonMultiLineString": {
+        "type": "object",
+        "title": "GeoJSON MultiLineString",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/GeoJsonGeometry"
+          },
+          {
+            "properties": {
+              "coordinates": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/GeoJsonPoint3D"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "GeoJsonMultiPolygon": {
+        "type": "object",
+        "title": "GeoJSON MultiPolygon",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/GeoJsonGeometry"
+          },
+          {
+            "properties": {
+              "coordinates": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/GeoJsonPoint3D"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "GeoJsonGeometryCollection": {
+        "type": "object",
+        "title": "GeoJSON GeometryCollection",
+        "required": [
+          "type",
+          "geometries"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "GeometryCollection"
+            ]
+          },
+          "geometries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GeoJsonGeometry"
+            }
           }
         }
       }

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -81,7 +81,6 @@ def test_schema_example(api_spec, path, schema_with_example):
     """
     if path[-1] == "properties":
         pytest.skip("This is probably not a schema example but an 'example' property")
-    assert "type" in schema_with_example
     assert "example" in schema_with_example
     example = schema_with_example['example']
     OpenApiValidator(api_spec=api_spec, schema=schema_with_example).validate(example)


### PR DESCRIPTION
Implements #131 - a job result is now a valid STAC Item that could be shipped with the data.

Only issue I see so far is that you need to specify a geometry and bbox. Is that too burdensome? 
Edit: According to a short survey in the recent dev telco, it is usually not a problem.