### PR TITLE
Cleaning up after recent changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 - The processes should not use the JSON Schema keyword `format` any longer. Instead use the custom keyword `subtype`. [#233](https://github.com/Open-EO/openeo-processes/issues/233)
-- PROJ definitions are deprecated in favor of EPSG codes, WKT2 and PROJJSON. [#58](https://github.com/Open-EO/openeo-processes/issues/58)
+- PROJ definitions are deprecated in favor of EPSG codes and WKT2. [#58](https://github.com/Open-EO/openeo-processes/issues/58)
 
 ### Removed
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -255,38 +255,42 @@ tags:
       To support more fine grained data types, a custom [JSON Schema keyword](https://tools.ietf.org/html/draft-handrews-json-schema-01#section-6.4) has been defined: `subtype`.
       It works similarly as the JSON Schema keyword [`format`](https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-7) and defines a number of subtypes for the native data types.
       These should be re-used in process schema definitions whenever suitable.
+      
+      If a general data type such as `string` or `number` is used in a schema, all subtypes with the same parent data type can be passed, too.
+      Clients should offer make passing subtypes as easy as passing a general data type.
+      For example, a parameter accepting strings must also allow passing a string with subtype `date` and thus clients should encourage this by also providing a date-picker.
 
-      | Subtype                   | Data type | Description |
-      | ------------------------- | --------- | ----------- |
-      | `band-name`               | string    | Either a unique band name (metadata field `name`) or a [common band name](https://github.com/radiantearth/stac-spec/tree/0.9.0/extensions/eo#common-band-names) (metadata field `common_name`) available in the data cube. If unique band name and common name conflict, the unique band name has higher priority. |
-      | `bounding-box`            | object    | A bounding box with the required fields `west`, `south`, `east`, `north` and optionally `base`, `height`, `crs`. The `crs` is a EPSG code, a WKT2:2018 string or a PROJ definition (deprecated). |
-      | `collection-id`           | string    | A collection id from the list of supported collections. Pattern: `^[A-Za-z0-9_\-\.~/]+$` |
-      | `date`                    | string    | Date only representation, as defined for `full-date` by [RFC 3339 in section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). The time zone is UTC. |
-      | `date-time`               | string    | Date and time representation, as defined for `date-time` by [RFC 3339 in section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). |
-      | `epsg-code`               | integer   | Specifies details about cartographic projections as [EPSG](http://www.epsg.org) code. |
-      | `file-paths`              | array     | An array with relative paths to user-uploaded files. Clients should assist to generate a list of files for folders. |
-      | `file-path`               | string    | A relative path to a user-uploaded file. Folders can't be specified. |
-      | `geojson`                 | object    | GeoJSON as defined by [RFC 7946](https://tools.ietf.org/html/rfc7946). [JSON Schemes for validation are available.](https://github.com/geojson/schema) |
-      | `input-format`            | string    | An input format supported by the back-end. |
-      | `input-format-options`    | object    | Key-value-pairs with arguments for the input format options supported by the back-end. |
-      | `job-id`                  | string    | A batch job id, either one of the jobs a user has stored or a publicly available job. Pattern: `^[A-Za-z0-9_\-\.~]+$` |
-      | `kernel`                  | array     | Image kernel, a multi-dimensional array of numbers. |
-      | `output-format`           | string    | An output format supported by the back-end. |
-      | `output-format-options`   | object    | Key-value-pairs with arguments for the output format options supported by the back-end. |
-      | `process-graph`           | object    | An parametrized process graph that is passed as an argument and is expected to be executed by the process. Parameters passed to the process graph are specified in a `parameters` property (see chapter "Parametrized Process Graphs" below). |
-      | `process-graph-id`        | string    | A process graph id, either one of the process graphs a user has stored or a publicly available process graph. Pattern: `^[A-Za-z0-9_\-\.~]+$` |
-      | `process-graph-variables` | object    | Key-value-pairs with values for variables that are defined by the process graph. The key of the pair is the `variable_id` for the value specified. |
-      | `proj-definition`         | string    | **DEPRECATED.** Specifies details about cartographic projections as [PROJ](https://proj.org/usage/quickstart.html) definition. |
-      | `raster-cube`             | object    | A raster data cube, an image collection stored at the back-end. Different back-ends have different internal representations for this data structure. |
-      | `temporal-interval`       | array     | A two-element array, which describes a left-closed temporal interval. The first element is the start of the date and/or time interval. The second element is the end of the date and/or time interval. The specified temporal strings follow the subtypes `date-time`, `date` (see above) and `time` (see below). |
-      | `temporal-intervals`      | array     | An array of two-element arrays, each being an array with subtype `temporal-interval` (see above). |
-      | `time`                    | string    | Time only representation, as defined for `full-time` by [RFC 3339 in section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). Although [RFC 3339 prohibits the hour to be '24'](https://tools.ietf.org/html/rfc3339#section-5.7), this definition allows the value '24' for the hour as end time in an interval in order to make it possible that left-closed time intervals can fully cover the day. |
-      | `udf-code`                | string    | The (multi-line) source code of an user-defined function (UDF). |
-      | `udf-runtime`             | string    | The name of an UDF runtime. |
-      | `udf-runtime-version`     | string    | The version of an UDF runtime. |
-      | `uri`                     | string    | A valid URI according to [RFC3986](https://tools.ietf.org/html/rfc3986). |
-      | `vector-cube`             | object    | A vector data cube, a vector collection stored at the back-end. Different back-ends have different internal representations for this data structure |
-      | `wkt2-definition`         | string    | Specifies details about cartographic projections as WKT2 string. Refers to the latest WKT2 version (currently [WKT2:2018](http://docs.opengeospatial.org/is/18-010r7/18-010r7.html) / ISO 19162:2018) unless otherwise stated by the process. |
+      | Subtype                   | Parent Type | Description |
+      | ------------------------- | ----------- | ----------- |
+      | `band-name`               | string      | Either a unique band name (metadata field `name`) or a [common band name](https://github.com/radiantearth/stac-spec/tree/0.9.0/extensions/eo#common-band-names) (metadata field `common_name`) available in the data cube. If unique band name and common name conflict, the unique band name has higher priority. |
+      | `bounding-box`            | object      | A bounding box with the required fields `west`, `south`, `east`, `north` and optionally `base`, `height`, `crs`. The `crs` is a EPSG code, a WKT2:2018 string or a PROJ definition (deprecated). |
+      | `collection-id`           | string      | A collection id from the list of supported collections. Pattern: `^[A-Za-z0-9_\-\.~/]+$` |
+      | `date`                    | string      | Date only representation, as defined for `full-date` by [RFC 3339 in section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). The time zone is UTC. |
+      | `date-time`               | string      | Date and time representation, as defined for `date-time` by [RFC 3339 in section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). |
+      | `epsg-code`               | integer     | Specifies details about cartographic projections as [EPSG](http://www.epsg.org) code. |
+      | `file-paths`              | array       | An array with relative paths to user-uploaded files. Clients should assist to generate a list of files for folders. |
+      | `file-path`               | string      | A relative path to a user-uploaded file. Folders can't be specified. |
+      | `geojson`                 | object      | GeoJSON as defined by [RFC 7946](https://tools.ietf.org/html/rfc7946). [JSON Schemes for validation are available.](https://github.com/geojson/schema) |
+      | `input-format`            | string      | An input format supported by the back-end. |
+      | `input-format-options`    | object      | Key-value-pairs with arguments for the input format options supported by the back-end. |
+      | `job-id`                  | string      | A batch job id, either one of the jobs a user has stored or a publicly available job. Pattern: `^[A-Za-z0-9_\-\.~]+$` |
+      | `kernel`                  | array       | Image kernel, a multi-dimensional array of numbers. |
+      | `output-format`           | string      | An output format supported by the back-end. |
+      | `output-format-options`   | object      | Key-value-pairs with arguments for the output format options supported by the back-end. |
+      | `process-graph`           | object      | An parametrized process graph that is passed as an argument and is expected to be executed by the process. Parameters passed to the process graph are specified in a `parameters` property (see chapter "Parametrized Process Graphs" below). |
+      | `process-graph-id`        | string      | A process graph id, either one of the process graphs a user has stored or a publicly available process graph. Pattern: `^[A-Za-z0-9_\-\.~]+$` |
+      | `process-graph-variables` | object      | Key-value-pairs with values for variables that are defined by the process graph. The key of the pair is the `variable_id` for the value specified. |
+      | `proj-definition`         | string      | **DEPRECATED.** Specifies details about cartographic projections as [PROJ](https://proj.org/usage/quickstart.html) definition. |
+      | `raster-cube`             | object      | A raster data cube, an image collection stored at the back-end. Different back-ends have different internal representations for this data structure. |
+      | `temporal-interval`       | array       | A two-element array, which describes a left-closed temporal interval. The first element is the start of the date and/or time interval. The second element is the end of the date and/or time interval. The specified temporal strings follow the subtypes `date-time`, `date` (see above) and `time` (see below). |
+      | `temporal-intervals`      | array       | An array of two-element arrays, each being an array with subtype `temporal-interval` (see above). |
+      | `time`                    | string      | Time only representation, as defined for `full-time` by [RFC 3339 in section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). Although [RFC 3339 prohibits the hour to be '24'](https://tools.ietf.org/html/rfc3339#section-5.7), this definition allows the value '24' for the hour as end time in an interval in order to make it possible that left-closed time intervals can fully cover the day. |
+      | `udf-code`                | string      | The (multi-line) source code of an user-defined function (UDF). |
+      | `udf-runtime`             | string      | The name of an UDF runtime. |
+      | `udf-runtime-version`     | string      | The version of an UDF runtime. |
+      | `uri`                     | string      | A valid URI according to [RFC3986](https://tools.ietf.org/html/rfc3986). |
+      | `vector-cube`             | object      | A vector data cube, a vector collection stored at the back-end. Different back-ends have different internal representations for this data structure |
+      | `wkt2-definition`         | string      | Specifies details about cartographic projections as WKT2 string. Refers to the latest WKT2 version (currently [WKT2:2018](http://docs.opengeospatial.org/is/18-010r7/18-010r7.html) / ISO 19162:2018) unless otherwise stated by the process. |
 
       ## Parametrized Process Graphs
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -259,7 +259,7 @@ tags:
       | Subtype                   | Data type | Description |
       | ------------------------- | --------- | ----------- |
       | `band-name`               | string    | Either a unique band name (metadata field `name`) or a [common band name](https://github.com/radiantearth/stac-spec/tree/0.9.0/extensions/eo#common-band-names) (metadata field `common_name`) available in the data cube. If unique band name and common name conflict, the unique band name has higher priority. |
-      | `bounding-box`            | object    | A bounding box with the required fields `west`, `south`, `east`, `north` and optionally `base`, `height`, `crs`. The `crs` is a EPSG code, a WKT2:2018 string, PROJJSON or a PROJ definition (deprecated). |
+      | `bounding-box`            | object    | A bounding box with the required fields `west`, `south`, `east`, `north` and optionally `base`, `height`, `crs`. The `crs` is a EPSG code, a WKT2:2018 string or a PROJ definition (deprecated). |
       | `collection-id`           | string    | A collection id from the list of supported collections. Pattern: `^[A-Za-z0-9_\-\.~/]+$` |
       | `date`                    | string    | Date only representation, as defined for `full-date` by [RFC 3339 in section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). The time zone is UTC. |
       | `date-time`               | string    | Date and time representation, as defined for `date-time` by [RFC 3339 in section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). |
@@ -277,7 +277,6 @@ tags:
       | `process-graph-id`        | string    | A process graph id, either one of the process graphs a user has stored or a publicly available process graph. Pattern: `^[A-Za-z0-9_\-\.~]+$` |
       | `process-graph-variables` | object    | Key-value-pairs with values for variables that are defined by the process graph. The key of the pair is the `variable_id` for the value specified. |
       | `proj-definition`         | string    | **DEPRECATED.** Specifies details about cartographic projections as [PROJ](https://proj.org/usage/quickstart.html) definition. |
-      | `projjson-definition`     | object    | Specifies details about cartographic projections as [PROJJSON](https://proj.org/projjson.html) definition. |
       | `raster-cube`             | object    | A raster data cube, an image collection stored at the back-end. Different back-ends have different internal representations for this data structure. |
       | `temporal-interval`       | array     | A two-element array, which describes a left-closed temporal interval. The first element is the start of the date and/or time interval. The second element is the end of the date and/or time interval. The specified temporal strings follow the subtypes `date-time`, `date` (see above) and `time` (see below). |
       | `temporal-intervals`      | array     | An array of two-element arrays, each being an array with subtype `temporal-interval` (see above). |
@@ -4407,10 +4406,8 @@ components:
       type: string
     collection_dimension_reference_system_spatial:
       description: >-
-        The spatial reference system for the data, specified as [EPSG code](http://www.epsg-registry.org/), [WKT2 (ISO 19162) string](http://docs.opengeospatial.org/is/18-010r7/18-010r7.html), [PROJJSON](https://proj.org/projjson.html) or [PROJ definition (deprecated)](https://proj.org/usage/quickstart.html). Defaults to EPSG code 4326.
+        The spatial reference system for the data, specified as [EPSG code](http://www.epsg-registry.org/), [WKT2 (ISO 19162) string](http://docs.opengeospatial.org/is/18-010r7/18-010r7.html) or [PROJ definition (deprecated)](https://proj.org/usage/quickstart.html). Defaults to EPSG code 4326.
       oneOf:
-        - type: object
-          description: PROJJSON
         - type: string
           description: WKT2 or PROJ definition
         - type: number


### PR DESCRIPTION
Changes:
1. Remove support for PROJJSON as CRS. Now that we use CRS as dimension, it would complicate the label handling due to PROJJSON not being a number or string.
2. Don't explicitly specify the subtypes if a general type has been specified. For example, temporal strings are always allowed if strings are allowed thus it's not required to mention them explicitly in schemas. Clients should allow all subtypes for the general types to be passed.

Related PR in processes: https://github.com/Open-EO/openeo-processes/pull/132
Related commit in openeo.org: https://github.com/Open-EO/openeo.org/commit/bf9e8271c5df11a5ea46d5e3c6300df7dd9ad8e2