### PR TITLE
Pass process metadata with data processing requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `GET /process_graphs`: Field `id` is required for each process.
+- For batch jobs (`/jobs`), services (`/services`) and sync. processing (`/result`) the property `process_graph` got replaced by `process`. It contains a process graph and optionally all process metadata. [#260](https://github.com/Open-EO/openeo-api/issues/260)
 
 ### Fixed
 - Added `$id` to JSON Schema file for subtypes.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2308,10 +2308,10 @@ paths:
               title: Synchronous Result Request
               type: object
               required:
-                - process_graph
+                - process
               properties:
-                process_graph:
-                  $ref: '#/components/schemas/process_graph'
+                process:
+                  $ref: '#/components/schemas/process_graph_with_metadata'
                 budget:
                   $ref: '#/components/schemas/budget'
                 plan:
@@ -2747,14 +2747,14 @@ paths:
               type: object
               required:
                 - type
-                - process_graph
+                - process
               properties:
                 title:
                   $ref: '#/components/schemas/eo_title'
                 description:
                   $ref: '#/components/schemas/eo_description'
-                process_graph:
-                  $ref: '#/components/schemas/process_graph'
+                process:
+                  $ref: '#/components/schemas/process_graph_with_metadata'
                 type:
                   $ref: '#/components/schemas/service_type'
                 enabled:
@@ -2799,8 +2799,8 @@ paths:
                   $ref: '#/components/schemas/eo_title'
                 description:
                   $ref: '#/components/schemas/eo_description'
-                process_graph:
-                  $ref: '#/components/schemas/process_graph'
+                process:
+                  $ref: '#/components/schemas/process_graph_with_metadata'
                 enabled:
                   $ref: '#/components/schemas/service_enabled'
                 configuration:
@@ -2831,7 +2831,7 @@ paths:
                 type: object
                 required:
                   - id
-                  - process_graph
+                  - process
                   - enabled
                   - type
                   - url
@@ -2844,8 +2844,8 @@ paths:
                     $ref: '#/components/schemas/eo_title'
                   description:
                     $ref: '#/components/schemas/eo_description'
-                  process_graph:
-                    $ref: '#/components/schemas/process_graph'
+                  process:
+                    $ref: '#/components/schemas/process_graph_with_metadata'
                   url:
                     $ref: '#/components/schemas/service_url'
                   type:
@@ -3007,14 +3007,14 @@ paths:
               title: Store Batch Job Request
               type: object
               required:
-                - process_graph
+                - process
               properties:
                 title:
                   $ref: '#/components/schemas/eo_title'
                 description:
                   $ref: '#/components/schemas/eo_description'
-                process_graph:
-                  $ref: '#/components/schemas/process_graph'
+                process:
+                  $ref: '#/components/schemas/process_graph_with_metadata'
                 plan:
                   $ref: '#/components/schemas/billing_plan_defaultable'
                 budget:
@@ -3058,8 +3058,8 @@ paths:
                   $ref: '#/components/schemas/eo_title'
                 description:
                   $ref: '#/components/schemas/eo_description'
-                process_graph:
-                  $ref: '#/components/schemas/process_graph'
+                process:
+                  $ref: '#/components/schemas/process_graph_with_metadata'
                 plan:
                   $ref: '#/components/schemas/billing_plan_defaultable'
                 budget:
@@ -3087,7 +3087,7 @@ paths:
                 type: object
                 required:
                   - id
-                  - process_graph
+                  - process
                   - status
                   - created
                 properties:
@@ -3097,8 +3097,8 @@ paths:
                     $ref: '#/components/schemas/eo_title'
                   description:
                     $ref: '#/components/schemas/eo_description'
-                  process_graph:
-                    $ref: '#/components/schemas/process_graph'
+                  process:
+                    $ref: '#/components/schemas/process_graph_with_metadata'
                   status:
                     $ref: '#/components/schemas/status'
                   progress:


### PR DESCRIPTION
 For batch jobs (`/jobs`), services (`/services`) and sync. processing (`/result`) the property `process_graph` got replaced by `process`. It contains a process graph and optionally all process metadata. For context see #260.
