### PR TITLE
Reintroduced the missing `offset` parameter for log endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased / Draft
 
+### Added
+- `/jobs/{job_id}/logs` and `GET /services/{service_id}/logs`: Reintroduced the missing `offset` parameter.
+
 ### Changed
 - `GET /process_graphs`: Field `id` is required for each process.
 
@@ -14,8 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed invalid EPSG code example.
 - Fixed invalid JSON Schema for process graph validation (used `from_argument` instead of `from_parameter`).
 - Clarified how `from_parameter` is resolved in case no value is given.
-- Removed outdated error codes from `errors.json`.
 - Clarified that back-ends not supporting pagination will return all resources.
+- Clarified `GET .../logs` endpoint behaviour.
+- Removed outdated error codes from `errors.json`.
 
 ## 1.0.0-rc.1 - 2020-01-31
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2898,13 +2898,26 @@ paths:
     get:
       summary: Logs for a secondary service
       operationId: debug-service
-      description: Logs for the secondary service.
+      description: >-
+        Shows log entries for the secondary service, usually for debugging purposes.
+        
+        Back-ends can log any information that may be relevant for a user.
+        Users can log information during data processing using respective
+        processes such as `debug`.
+
+        If requested consecutively while the secondary service is enabled, it is
+        RECOMMENDED that clients use the offset parameter to get only the entries
+        they have not received yet.
+
+        While pagination itself is OPTIONAL, the `offset` parameter is REQUIRED
+        to be implemented by back-ends.
       tags:
         - Secondary Services
       security:
         - Bearer: []
       parameters:
         - $ref: '#/components/parameters/service_id'
+        - $ref: '#/components/parameters/log_offset'
         - $ref: '#/components/parameters/pagination_limit'
       responses:
         '200':
@@ -3219,7 +3232,19 @@ paths:
     get:
       summary: Logs for a batch job
       operationId: debug-job
-      description: Logs for the batch job.
+      description: |-
+        Shows log entries for the batch job, usually for debugging purposes.
+        
+        Back-ends can log any information that may be relevant for a user.
+        Users can log information during data processing using respective
+        processes such as `debug`.
+
+        If requested consecutively while a job is running, it is RECOMMENDED
+        that clients use the offset parameter to get only the entries they have
+        not received yet.
+
+        While pagination itself is OPTIONAL, the `offset` parameter is REQUIRED
+        to be implemented by back-ends.
       tags:
         - Data Processing
         - Batch Jobs
@@ -3227,6 +3252,7 @@ paths:
         - Bearer: []
       parameters:
         - $ref: '#/components/parameters/job_id'
+        - $ref: '#/components/parameters/log_offset'
         - $ref: '#/components/parameters/pagination_limit'
       responses:
         '200':
@@ -5470,9 +5496,9 @@ components:
       name: limit
       description: |-
         This parameter enables pagination for the endpoint and specifies the maximum number of
-        elements that arrays in the top-level object (e.g. jobs, log entries, secondary services,
-        files etc.) are allowed to contain. The only exception is the `links` array, which
-        MUST NOT be paginated as otherwise the pagination links may be missing ins responses.
+        elements that arrays in the top-level object (e.g. jobs or log entries) are allowed to contain.
+        The only exception is the `links` array, which MUST NOT be paginated as otherwise the
+        pagination links may be missing ins responses.
         If the parameter is not provided or empty, all elements are returned.
         
         Pagination is OPTIONAL and back-ends and clients may not support it.
@@ -5483,7 +5509,7 @@ components:
         If the response is paginated, the links array MUST be used to propagate the 
         links for pagination with pre-defined `rel` types. See the links array schema
         for supported `rel` types.
-
+        
         *Note:* Implementations can use all kind of pagination techniques, depending on what is
         supported best by their infrastructure. So it doesn't care whether it is page-based,
         offset-based or uses tokens for pagination. The clients will use whatever is specified
@@ -5494,6 +5520,14 @@ components:
       schema:
         type: integer
         minimum: 1
+    log_offset:
+      name: offset
+      description: The last identifier (property `id` of a log entry) the client has received. If provided, the back-ends only sends the entries that occured after the specified identifier. If not provided or empty, start with the first entry.
+      in: query
+      allowEmptyValue: true
+      example: "log1234"
+      schema:
+        type: string
     process_graph_id:
       name: process_graph_id
       in: path


### PR DESCRIPTION
This parameter got lost during the pagination work for RC1. Re-added it again so that the log endpoints can be queried better while processing. This was meant to be part of RC1. Also improved the description for the log endpoints.