### PR TITLE
Finetune OpenID Connect scope documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `year` subtype to subtype-schemas.json. `year` was also added to subtypes `temporal-interval` and `temporal-intervals`. [#267](https://github.com/Open-EO/openeo-api/issues/267)
 
 ### Changes
+- `GET /credentials/oidc`: field `scopes` is not required anymore, but when specified, it should contain the `openid` scope. [#288](https://github.com/Open-EO/openeo-api/pull/288)
 - `GET /.well-known/openeo` and `GET /`: `production` fields default to `false` instead of `true`.
 - `errors.json`: The pre-defined error messages have been reworked.  [#272](https://github.com/Open-EO/openeo-api/issues/272), [#273](https://github.com/Open-EO/openeo-api/issues/273)
     - Added `FolderOperationUnsupported`, `UnsupportedApiVersion`, `PermissionsInsufficient`, `ProcessGraphIdDoesntMatch` and `PredefinedProcessExists`.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2063,23 +2063,6 @@ paths:
         Discovery](http://openid.net/specs/openid-connect-discovery-1_0.html).
 
 
-        For each OpenID provider, a name and the issuer location MUST be listed.
-        A description and related links can OPTIONALLY be added. The [issuer
-        location](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig)
-        (also referred to as 'authority' in client libraries) is the URL of the
-        OpenID provider, which conforms to a set of rules:
-
-        1. After appending `/.well-known/openid-configuration` to the URL, a
-        [HTTP/1.1 GET
-        request](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationRequest)
-        to the concatenated URL must return a [OpenID Discovery Configuration
-        Response](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationResponse).
-        The response provides all information required to authenticate using
-        OpenID Connect.
-
-        2. The URL MUST NOT contain a terminating forward slash `/`.
-
-
         It is highly RECOMMENDED to implement OpenID Connect for public services
         in favor of Basic authentication.
 
@@ -2087,8 +2070,8 @@ paths:
         openEO clients MUST use the **access token** as part of the Bearer token
         for authorization in subsequent API calls (see also the information
         about Bearer tokens in this document). Clients MUST NOT use the id token
-        or the authorization code. The access token provided by this the OpenID
-        Provider does not always provide information about the issuer (i.e. the
+        or the authorization code. The access token provided by an OpenID
+        Provider does not necessarily provide information about the issuer (i.e. the
         OpenID provider) and therefore a prefix MUST be added to the Bearer
         Token sent in subsequent API calls to protected endpoints. The Bearer
         Token sent to protected endpoints MUST consist of the authentication
@@ -2129,7 +2112,6 @@ paths:
                       required:
                         - id
                         - issuer
-                        - scopes
                         - title
                       properties:
                         id:
@@ -2142,19 +2124,26 @@ paths:
                           type: string
                           format: uri
                           description: >-
-                            The [issuer
-                            location](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig),
-                            i.e. the URL of the OpenID provider (see endpoint
-                            description).
+                            The [issuer location](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig)
+                            (also referred to as 'authority' in some client libraries) is the URL of the
+                            OpenID provider, which conforms to a set of rules:
+
+                            1. After appending `/.well-known/openid-configuration` to the URL, a
+                            [HTTP/1.1 GET
+                            request](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationRequest)
+                            to the concatenated URL must return a [OpenID Discovery Configuration
+                            Response](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationResponse).
+                            The response provides all information required to authenticate using
+                            OpenID Connect.
+
+                            2. The URL MUST NOT contain a terminating forward slash `/`.
+
                           example: 'https://accounts.google.com'
                         scopes:
                           type: array
                           description: >-
-                            A list of OpenID Scopes that the client MUST use.
-
-
-                            If empty, the default scopes of OpenID Connect MUST
-                            be used.
+                            A list of OpenID Connect scopes that the client MUST use.
+                            If scopes are specified, the list MUST at least contain the `openid` scope.
                           items:
                             type: string
                         title:
@@ -2181,7 +2170,7 @@ paths:
                       title: Google
                       description: Login with your Google Account.
                       scopes:
-                        - oidc
+                        - openid
                         - profile
                         - email
                         - earthengine


### PR DESCRIPTION
https://openeo.org/documentation/1.0/developers/api/reference.html#operation/authenticate-oidc

under `/credientials/oidc`, the `scopes` fields:

    scopes (required)   A list of OpenID Scopes that the client MUST use.
                        If empty, the default scopes of OpenID Connect MUST be used.


This is bit confusing: it is required on one hand, but can be empty (in which case default scopes must be used)

I'm also not sure what _default_ scopes mean in this context, but as far as I know, only `openid` is a required scope to enable OpenID Connect. I would just simplify the doc to state that.