### PR TITLE
Add type to UDF Runtime for better code generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `GET /me`: Added optional `name` property to better separate an internal user id from a displayable user name. Adopted description of `user_id` accordingly.
-- `GET /udf_runtimes`: Added optional `title` property for UDF runtimes. [#266](https://github.com/Open-EO/openeo-api/issues/266)
+- `GET /udf_runtimes`: 
+    - Added optional `title` property for UDF runtimes. [#266](https://github.com/Open-EO/openeo-api/issues/266)
+    - Added required `type` property for UDF runtimes to support better code generation.
 - `GET /service_types`: Added optional `title` and `description` properties for service types. [#266](https://github.com/Open-EO/openeo-api/issues/266)
 - `GET /file_formats`: Added optional `description` property for file formats. [#266](https://github.com/Open-EO/openeo-api/issues/266)
 - `GET /collections/{collection_id}` and `GET /processes`: Mention of link `rel` type `example` to refer to examples. [#285](https://github.com/Open-EO/openeo-api/issues/285)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3238,6 +3238,7 @@ components:
       type: object
       required:
         - type
+        - default
       properties:
         title:
           $ref: '#/components/schemas/object_title'
@@ -3280,10 +3281,10 @@ components:
         - $ref: '#/components/schemas/udf_runtime'
         - title: Programming language
           required:
-            - default
             - versions
           properties:
             default:
+              type: string
               description: The default version. MUST be one of the keys in the `versions` object.
             versions:
               title: Programming language versions
@@ -3349,7 +3350,6 @@ components:
         - title: Docker container
           required:
             - docker
-            - default
             - tags
           properties:
             docker:
@@ -3358,6 +3358,7 @@ components:
                 Identifier of a Docker image on Docker Hub or a
                 private repository, i.e. the docker image name.
             default:
+              type: string
               description: The default tag. MUST be one of the values in the `tags` array.
             tags:
               type: array
@@ -4664,8 +4665,12 @@ components:
             $ref: '#/components/schemas/link'
         process_graph:
           $ref: '#/components/schemas/process_graph'
-    nullable_process:
+    user_defined_process_meta:
+      title: User-defined Process Metadata
+      description: A user-defined process, may only contain metadata and no process graph.
       type: object
+      required:
+        - id
       properties:
         summary:
           nullable: true
@@ -4677,14 +4682,6 @@ components:
           nullable: true
       allOf:
         - $ref: '#/components/schemas/process'
-    user_defined_process_meta:
-      title: User-defined Process Metadata
-      description: A user-defined process, may only contain metadata and no process graph.
-      type: object
-      required:
-        - id
-      allOf:
-        - $ref: '#/components/schemas/nullable_process'
     process_graph_with_metadata:
       title: Process Graph with metadata
       description: A process graph, optionally enriched with process metadata.
@@ -4694,8 +4691,16 @@ components:
       properties:
         id:
           nullable: true
+        summary:
+          nullable: true
+        description:
+          nullable: true
+        parameters:
+          nullable: true
+        returns:
+          nullable: true
       allOf:
-        - $ref: '#/components/schemas/nullable_process'
+        - $ref: '#/components/schemas/process'
     process_id:
       type: string
       description: |-

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1622,13 +1622,13 @@ paths:
                   programming language environment or Docker-based.
                 additionalProperties:
                   x-additionalPropertiesName: UDF Runtime name
-                  oneOf:
-                    - $ref: '#/components/schemas/udf_programming_language'
-                    - $ref: '#/components/schemas/udf_docker'
+                  allOf:
+                    - $ref: '#/components/schemas/udf_runtime'
                 example:
                   PHP7:
                     title: PHP v7.x
                     description: Just an example how to reference a docker image.
+                    type: docker
                     docker: openeo/udf-php7
                     default: latest
                     tags:
@@ -1642,6 +1642,7 @@ paths:
                   R:
                     title: R v3.x for Statistical Computing
                     description: R programming language with `Rcpp` and `rmarkdown` extensions installed.
+                    type: language
                     default: 3.5.2
                     versions:
                       3.1.0:
@@ -3235,11 +3236,23 @@ components:
   schemas:
     udf_runtime:
       type: object
+      required:
+        - type
       properties:
         title:
           $ref: '#/components/schemas/object_title'
         description:
           $ref: '#/components/schemas/description'
+        type:
+          type: string
+          description: |-
+            The type of the UDF runtime.
+
+            Pre-defined types are:
+            * `language` for Programming Languages and
+            * `docker` for Docker Containers.
+            
+            The types can potentially be extended by back-ends.
         default:
           type: string
         links:
@@ -3257,11 +3270,16 @@ components:
             [common relation types in openEO](#section/API-Principles/Web-Linking).
           items:
             $ref: '#/components/schemas/link'
+      discriminator:
+        propertyName: type
+        mapping:
+          language: '#/components/schemas/udf_programming_language'
+          docker: '#/components/schemas/udf_docker'
     udf_programming_language:
-      title: Programming language
       allOf:
         - $ref: '#/components/schemas/udf_runtime'
-        - required:
+        - title: Programming language
+          required:
             - default
             - versions
           properties:
@@ -3326,10 +3344,10 @@ components:
                           items:
                             $ref: '#/components/schemas/link'
     udf_docker:
-      title: Docker container
       allOf:
         - $ref: '#/components/schemas/udf_runtime'
-        - required:
+        - title: Docker container
+          required:
             - docker
             - default
             - tags


### PR DESCRIPTION
This adds a required field `type` to each UDF runtime in `/udf_runtimes`. This is a breaking change, which means each back-end needs to add the field to be valid against the spec.

Ususally, I'd not like breaking changes in this stage, but recently I worked with @aljacob to improve the results you get from openapi-generator. This change is required to get a well-defined class inheritance for the generated classes, without this change the generated classes are pretty useless. Thus we thought it's an easy fix for back-ends to make the OpenAPI document more future-proof and allow new implementers to auto-generate better code. We hope this eases adoption. 

Due to the breaking change I'm asking for approvals / concerns / vetos from back-ends here. This shouldn't be an issue for clients.