### PR TITLE
Revert namespace default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `GET /.well-known/openeo` and `GET /`: `production` fields default to `false` instead of `true`.
 - `GET /collections` and `GET /collections/{collection_id}`: Additional dimensions in `cube:properties` can only be of type `other`.
 - Allow all STAC versions that are compatible to STAC 0.9.0.
-- Process graph nodes have an additional field `namespace` to distinguish pre-defined and user-defined processes. The old behavior to prioritize user-defined over pre-defined processes is still the default. [#305](https://github.com/Open-EO/openeo-api/issues/305)
+- Process graph nodes have an additional field `namespace` to distinguish pre-defined and user-defined processes. The default behavior still prioritizes user-defined over pre-defined processes. [#305](https://github.com/Open-EO/openeo-api/issues/305)
 - Added `format: commonmark` to all properties supporting CommonMark formatting.
 - `errors.json`: The pre-defined error messages have been reworked.  [#272](https://github.com/Open-EO/openeo-api/issues/272), [#273](https://github.com/Open-EO/openeo-api/issues/273)
     - Added `FolderOperationUnsupported`, `UnsupportedApiVersion`, `PermissionsInsufficient`, `ProcessGraphIdDoesntMatch` and `PredefinedProcessExists`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `GET /.well-known/openeo` and `GET /`: `production` fields default to `false` instead of `true`.
 - `GET /collections` and `GET /collections/{collection_id}`: Additional dimensions in `cube:properties` can only be of type `other`.
 - Allow all STAC versions that are compatible to STAC 0.9.0.
-- Process graph nodes have an additional field `namespace` to distinguish pre-defined and user-defined processes. The old behavior to prioritize user-defined over pre-defined processes has been removed. [#305](https://github.com/Open-EO/openeo-api/issues/305)
+- Process graph nodes have an additional field `namespace` to distinguish pre-defined and user-defined processes. The old behavior to prioritize user-defined over pre-defined processes is still the default. [#305](https://github.com/Open-EO/openeo-api/issues/305)
 - Added `format: commonmark` to all properties supporting CommonMark formatting.
 - `errors.json`: The pre-defined error messages have been reworked.  [#272](https://github.com/Open-EO/openeo-api/issues/272), [#273](https://github.com/Open-EO/openeo-api/issues/273)
     - Added `FolderOperationUnsupported`, `UnsupportedApiVersion`, `PermissionsInsufficient`, `ProcessGraphIdDoesntMatch` and `PredefinedProcessExists`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `GET /.well-known/openeo` and `GET /`: `production` fields default to `false` instead of `true`.
 - `GET /collections` and `GET /collections/{collection_id}`: Additional dimensions in `cube:properties` can only be of type `other`.
 - Allow all STAC versions that are compatible to STAC 0.9.0.
-- Process graph nodes have an additional field `namespace` to distinguish pre-defined and user-defined processes. The default behavior still prioritizes user-defined over pre-defined processes. [#305](https://github.com/Open-EO/openeo-api/issues/305)
+- Process graph nodes have an additional field `namespace` to distinguish pre-defined and user-defined processes. The default behavior has not changed. [#305](https://github.com/Open-EO/openeo-api/issues/305)
 - Added `format: commonmark` to all properties supporting CommonMark formatting.
 - `errors.json`: The pre-defined error messages have been reworked.  [#272](https://github.com/Open-EO/openeo-api/issues/272), [#273](https://github.com/Open-EO/openeo-api/issues/273)
     - Added `FolderOperationUnsupported`, `UnsupportedApiVersion`, `PermissionsInsufficient`, `ProcessGraphIdDoesntMatch` and `PredefinedProcessExists`.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4728,6 +4728,7 @@ components:
         Unique identifier for the process.
         
         MUST be unique across its namespace (e.g. pre-defined processes or user-defined processes).
+        Additionally, user-defined processes with an identifier equal to any pre-defined process MUST be rejected.
       pattern: '^\w+$'
       example: ndvi
     process_summary:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4711,10 +4711,17 @@ components:
       example: null
       description: |-
         The namespace the `process_id` is valid for.
+
+        The following options are pre-defined by the openEO API, but additional
+        namespaces may be introduced by back-ends or in a future version of the API.
         
-        By default, the namespace is `null`, which includes all pre-defined processes listed at `GET /processes`.
-        The namespace `user` refers to all user-defined processes listed as `GET /process_graphs`.
-        Additional namespaces may be introduced by back-ends or in a future version of the API.
+        * `null` (default): Checks both user-defined and pre-defined processes,
+           but prefers user-defined processes if both are available.
+           This allows users to replace missing pre-defined processes with
+           user-defined processes, e.g. processes from https://processes.openeo.org
+           that have a process graph included.
+        * `backend`: Uses exclusively the pre-defined processes listed at `GET /processes`.
+        * `user`: Uses exclusively the user-defined processes listed at  listed as `GET /process_graphs`.  
     process_id:
       type: string
       description: |-

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4731,11 +4731,13 @@ components:
     process_id:
       type: string
       description: |-
-        Unique identifier for the process.
+        An identifier for the process.
         
-        MUST be unique across its namespace (e.g. pre-defined processes or user-defined processes).
-        Clients SHOULD warn the user if a user-defined process is added with an identifier that
-        exists in the pre-defined processes.
+        The identifier MUST be unique across its namespace (e.g. pre-defined
+        processes or user-defined processes).
+
+        Clients SHOULD warn the user if a user-defined process is added with the 
+        same identifier as one of the pre-defined process.
       pattern: '^\w+$'
       example: ndvi
     process_summary:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4717,16 +4717,11 @@ components:
         
         * `null` (default): Checks both user-defined and pre-defined processes,
            but prefers user-defined processes if both are available.
-           This allows users to replace missing pre-defined processes with
-           user-defined processes for portability, e.g. common processes from
-           [processes.openeo.org](https://processes.openeo.org) that have a process graph
-           included.
+           This allows users to add missing pre-defined processes for portability,
+           e.g. common processes from [processes.openeo.org](https://processes.openeo.org)
+           that have a process graph included.
            If a user-defined process is prioritized over a pre-defined process,
            a log entry SHOULD be added.
-           To improve reproducibility, it is RECOMMENDED that back-ends persist
-           the namespace that would be selected at the time the process is
-           submitted so that adding or removing processes doesn't change the
-           processing results in the future.
         * `backend`: Uses exclusively the pre-defined processes listed at `GET /processes`.
         * `user`: Uses exclusively the user-defined processes listed at `GET /process_graphs`.
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4721,25 +4721,21 @@ components:
            user-defined processes for portability, e.g. common processes from
            [processes.openeo.org](https://processes.openeo.org) that have a process graph
            included.
+           If a user-defined process is prioritized over a pre-defined process,
+           a log entry SHOULD be added.
+           To ensure reproducibility, back-ends SHOULD persist the namespace that
+           is prioritized at the time the process is submitted so that adding or
+           removing processes doesn't change the processing results in the future.
         * `backend`: Uses exclusively the pre-defined processes listed at `GET /processes`.
         * `user`: Uses exclusively the user-defined processes listed at `GET /process_graphs`.
-
-        Note on collisions: The only way a collision between user-defined processes and
-        pre-defined processes can occur is when back-ends introduce a new process with an
-        identifier already used by users. User-defined processes with an identifier used by
-        a pre-defined process MUST be rejected. To ensure reproducibility, back-ends SHOULD
-        persist the namespace that is prioritized at the time the process is submitted.
-        If a collision occurs after a has back-end introduced a new pre-defined process
-        (i.e. a user-defined process is prioritized over a pre-defined process),
-        a log entry should be added so that the user is informed about the availability of the
-        new process.
     process_id:
       type: string
       description: |-
         Unique identifier for the process.
         
         MUST be unique across its namespace (e.g. pre-defined processes or user-defined processes).
-        Additionally, user-defined processes with an identifier equal to any pre-defined process MUST be rejected.
+        Clients SHOULD warn the user if a user-defined process is added with an identifier that
+        exists in the pre-defined processes.
       pattern: '^\w+$'
       example: ndvi
     process_summary:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -205,7 +205,7 @@ info:
     
     **Back-end providers** MUST follow the schema for predefined processes as in [`GET /processes`](/#tag/Process-Discovery) to define new processes. This includes:
 
-    * Choosing a intuitive and ideally unique name as process id, consisting of only letters (a-z), numbers and underscores.
+    * Choosing a intuitive process id, consisting of only letters (a-z), numbers and underscores. It MUST be unique across the pre-defined processes.
     * Defining the parameters and their exact (JSON) schemes.
     * Specifying the return value of a process also with a (JSON) schema.
     * Providing examples or compliance tests.
@@ -213,7 +213,7 @@ info:
     
     **Users** MUST follow the schema for user-defined processes as in [`GET /process_graphs`](/#tag/User-Defined-Processes) to define new processes. This includes:
 
-    * Choosing a intuitive and ideally unique name as process id, consisting of only letters (a-z), numbers and underscores.
+    * Choosing a intuitive name as process id, consisting of only letters (a-z), numbers and underscores. It MUST be unique across the user-defined processes.
     * Defining the algorithm as a process graph.
     * Optionally, specifying the additional metadata for processes.
 
@@ -273,7 +273,7 @@ info:
 
     One of the nodes in a map of processes (the final one) MUST have the `result` flag set to `true`, all the other nodes can omit it as the default value is `false`. Having such a node is important as multiple end nodes are possible, but in most use cases it is important to exactly specify the return value to be used by other processes. Each child process graph must also specify a result node similar to the "main" process graph.
 
-    `process_id` MUST be a valid process ID in the `namespace` given. By default, the namespace is `null`, which includes all pre-defined processes listed at `GET /processes`. The namespace `user` refers to all user-defined processes listed as `GET /process_graphs`. Additional namespaces may be introduced later.
+    `process_id` MUST be a valid process ID in the `namespace` given. Clients SHOULD warn the user if a user-defined process is added with the same identifier as one of the pre-defined process.
 
     ### Arguments
 
@@ -4730,10 +4730,8 @@ components:
     process_id:
       type: string
       description: |-
-        An identifier for the process.
-        
-        The identifier MUST be unique across its namespace (e.g. pre-defined
-        processes or user-defined processes).
+        The identifier for the process. It MUST be unique across its namespace
+        (e.g. pre-defined processes or user-defined processes).
 
         Clients SHOULD warn the user if a user-defined process is added with the 
         same identifier as one of the pre-defined process.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4729,6 +4729,9 @@ components:
            processing results in the future.
         * `backend`: Uses exclusively the pre-defined processes listed at `GET /processes`.
         * `user`: Uses exclusively the user-defined processes listed at `GET /process_graphs`.
+
+        If multiple processes with the same identifier exist, Clients SHOULD
+        inform the user that it's recommended to select a namespace.
     process_id:
       type: string
       description: |-

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4718,10 +4718,21 @@ components:
         * `null` (default): Checks both user-defined and pre-defined processes,
            but prefers user-defined processes if both are available.
            This allows users to replace missing pre-defined processes with
-           user-defined processes, e.g. processes from https://processes.openeo.org
-           that have a process graph included.
+           user-defined processes for portability, e.g. common processes from
+           [processes.openeo.org](https://processes.openeo.org) that have a process graph
+           included.
         * `backend`: Uses exclusively the pre-defined processes listed at `GET /processes`.
-        * `user`: Uses exclusively the user-defined processes listed at  listed as `GET /process_graphs`.  
+        * `user`: Uses exclusively the user-defined processes listed at `GET /process_graphs`.
+
+        Note on collisions: The only way a collision between user-defined processes and
+        pre-defined processes can occur is when back-ends introduce a new process with an
+        identifier already used by users. User-defined processes with an identifier used by
+        a pre-defined process MUST be rejected. To ensure reproducibility, back-ends SHOULD
+        persist the namespace that is prioritized at the time the process is submitted.
+        If a collision occurs after a has back-end introduced a new pre-defined process
+        (i.e. a user-defined process is prioritized over a pre-defined process),
+        a log entry should be added so that the user is informed about the availability of the
+        new process.
     process_id:
       type: string
       description: |-

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4720,8 +4720,7 @@ components:
            This allows users to add missing pre-defined processes for portability,
            e.g. common processes from [processes.openeo.org](https://processes.openeo.org)
            that have a process graph included.
-           If a user-defined process is prioritized over a pre-defined process,
-           a log entry SHOULD be added.
+           It is RECOMMENDED to log the namespace selected by the back-end for debugging purposes.
         * `backend`: Uses exclusively the pre-defined processes listed at `GET /processes`.
         * `user`: Uses exclusively the user-defined processes listed at `GET /process_graphs`.
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4723,9 +4723,10 @@ components:
            included.
            If a user-defined process is prioritized over a pre-defined process,
            a log entry SHOULD be added.
-           To ensure reproducibility, back-ends SHOULD persist the namespace that
-           is prioritized at the time the process is submitted so that adding or
-           removing processes doesn't change the processing results in the future.
+           To improve reproducibility, it is RECOMMENDED that back-ends persist
+           the namespace that would be selected at the time the process is
+           submitted so that adding or removing processes doesn't change the
+           processing results in the future.
         * `backend`: Uses exclusively the pre-defined processes listed at `GET /processes`.
         * `user`: Uses exclusively the user-defined processes listed at `GET /process_graphs`.
     process_id:


### PR DESCRIPTION
I just realized again why we haven't had namespaces ( https://github.com/Open-EO/openeo-api/pull/309 ) in the API: User could simply replace missing pre-defined processes (e.g. normalized_difference) with our "alternative" processing instructions in openeo-processes. Just store it as user-defined process and it still runs. That's now broken with namespaces.

Thus, I partly revert the changes introduced in #309: The default behavior for a process graph is again preferring user-defined over pre-defined processes.
The namespaces are now a backward compatible addition to explicitly choosing the pre- or user-defined process.