### PR TITLE
Fix security-related CORS issues regarding to credentials #41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Units for STAC dimensions in `cube:dimensions` should now be compliant to UDUNITS-2 units (singular) whenever available.
 
 ### Fixed
+- Cross-Origin Resource Sharing (CORS):
+  - **SECURITY**: It is recommended to set `Access-Control-Allow-Origin` to `*` instead of reflecting the origin. [#41](https://github.com/Open-EO/openeo-api/issues/41)
+  - **SECURITY**: It is recommended to NOT send the `Access-Control-Allow-Credentials` header any more. [#41](https://github.com/Open-EO/openeo-api/issues/41)
+  - Added missing `Link` header to `Access-Control-Expose-Headers`. [#331](https://github.com/Open-EO/openeo-api/issues/331)
 - `GET /`: Missing option `OPTIONS` added to allowed `methods` for the `endpoints`. [#324](https://github.com/Open-EO/openeo-api/issues/324)
 - For `PATCH` requests: Clarified that no default values apply (for `budget`, `enabled` and `plan`). Data is only changed on the back-end if new data is explicitly specified by the client.
 - For `POST` requests with a `plan` property: Clarify that the default value is `null`.
-- Cross-Origin Resource Sharing (CORS): Added missing `Link` header to `Access-Control-Expose-Headers`. [#331](https://github.com/Open-EO/openeo-api/issues/331)
 
 ## 1.0.0 - 2020-07-17
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -138,6 +138,8 @@ info:
     Source: [https://en.wikipedia.org/wiki/Cross-origin_resource_sharing](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing)
     
     openEO-based back-ends are usually hosted on a different domain / host than the client that is requesting data from the back-end. Therefore most requests to the back-end are blocked by all modern browsers. This leads to the problem that the JavaScript library and any browser-based application can't access back-ends. Therefore, all back-end providers SHOULD support CORS to enable browser-based applications to access back-ends. [CORS is a recommendation of the W3C organization](https://www.w3.org/TR/cors/). The following chapters will explain how back-end providers can implement CORS support.
+
+    **Tip**: Most servers can send the required headers and the responses to the OPTIONS requests automatically for all endpoints. Otherwise you may also use a proxy server to add the headers and OPTIONS responses.
     
     ## CORS headers
     
@@ -146,10 +148,9 @@ info:
     | Name                             | Description                                                  | Example |
     | -------------------------------- | ------------------------------------------------------------ | ------- |
     | Access-Control-Allow-Origin      | Allowed origin for the request, including protocol, host and port or `*` for all origins. It is RECOMMENDED to return the value `*` to allow requests from browser-based implementations such as the Web Editor. | `*` |
-    | Access-Control-Expose-Headers    | Some endpoints send non-safelisted HTTP response headers such as `OpenEO-Identifier` and `OpenEO-Costs`. All headers except `Cache-Control`, `Content-Language`, `Content-Type`, `Expires`, `Last-Modified` and `Pragma` must be listed in this header. Currently, the openEO API requires at least the following headers to be listed: `Location, OpenEO-Identifier, OpenEO-Costs, Link`. | `Location, OpenEO-Identifier, OpenEO-Costs, Link` |
+    | Access-Control-Expose-Headers    | In addition to the white-listed HTTP headers `Cache-Control`, `Content-Language`, `Content-Type`, `Expires`, `Last-Modified` and `Pragma`, some endpoints need to send additional HTTP response headers such as `OpenEO-Identifier`. All headers that should be made available to browser-based clients MUST be listed in this header. Currently, the openEO API requires at least the following headers to be listed: `Link`, `Location`, `OpenEO-Costs` and `OpenEO-Identifier`. | `Link, Location, OpenEO-Costs, OpenEO-Identifier` |
     
     
-    **Tip**: Most server can send the required headers and the responses to the OPTIONS requests globally. Otherwise you may want to use a proxy server to add the headers and OPTIONS responses.
     
     ### Example request and response
     
@@ -175,11 +176,12 @@ info:
     
     ## OPTIONS method
     
-    All endpoints must respond to the `OPTIONS` HTTP method. This is a response for the preflight requests made by web browsers before sending the actual request (e.g. `POST /jobs`). It needs to respond with a status code of `204` and no response body. In addition to the HTTP headers shown in the table above, the following HTTP headers MUST be included with every response to an `OPTIONS` request:
+    All endpoints must respond to the `OPTIONS` HTTP method. This is a response for the preflight requests made by web browsers before sending the actual request (e.g. `POST /jobs`). It needs to respond with a status code of `204` and no response body.
+    **In addition** to the HTTP headers shown in the table above, the following HTTP headers MUST be included with every response to an `OPTIONS` request:
     
     | Name                             | Description                                                  | Example |
     | -------------------------------- | ------------------------------------------------------------ | ------- |
-    | Access-Control-Allow-Headers     | Comma-separated list of HTTP headers allowed to be send. MUST contain at least `Authorization` if any kind of authorization is implemented by the back-end. | `Authorization, Content-Type` |
+    | Access-Control-Allow-Headers     | Comma-separated list of HTTP headers allowed to be sent with the actual (non-preflight) request. MUST contain at least `Authorization` if any kind of authorization is implemented by the back-end. | `Authorization, Content-Type` |
     | Access-Control-Allow-Methods     | Comma-separated list of HTTP methods allowed to be requested. Back-ends MUST list all implemented HTTP methods for the endpoint. | `OPTIONS, GET, POST, PATCH, PUT, DELETE` |
     | Content-Type                     | SHOULD return the content type delivered by the request that the permission is requested for. | `application/json` |
     
@@ -195,6 +197,8 @@ info:
     Access-Control-Request-Headers: Authorization, Content-Type
     ```
     
+    Note that the `Access-Control-Request-*` headers are automatically attached to the requests by the browsers.
+
     Response:
     
     ```http

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -139,17 +139,48 @@ info:
     
     openEO-based back-ends are usually hosted on a different domain / host than the client that is requesting data from the back-end. Therefore most requests to the back-end are blocked by all modern browsers. This leads to the problem that the JavaScript library and any browser-based application can't access back-ends. Therefore, all back-end providers SHOULD support CORS to enable browser-based applications to access back-ends. [CORS is a recommendation of the W3C organization](https://www.w3.org/TR/cors/). The following chapters will explain how back-end providers can implement CORS support.
     
-    ## OPTIONS method
+    ## CORS headers
     
-    All endpoints must respond to the `OPTIONS` HTTP method. This is a response for the preflight requests made by the browsers. It needs to respond with a status code of `204` and send the HTTP headers shown in the table below. No body needs to be provided.
+    The following headers MUST be included with every response:
     
     | Name                             | Description                                                  | Example |
     | -------------------------------- | ------------------------------------------------------------ | ------- |
-    | Access-Control-Allow-Origin      | Allowed origin for the request, including protocol, host and port. It is RECOMMENDED to return the value of the request's origin header. If no `Origin` is sent to the back-end CORS headers SHOULD NOT be sent at all. | `http://client.isp.com:80` |
-    | Access-Control-Allow-Credentials | If authorization is implemented by the back-end the value MUST be `true`. | `true` |
-    | Access-Control-Allow-Headers     | Comma-separated list of HTTP headers allowed to be send. MUST contain at least `Authorization` if authorization is implemented by the back-end. | ` Authorization, Content-Type` |
-    | Access-Control-Allow-Methods     | Comma-separated list of HTTP methods allowed to be requested. Back-ends MUST list all implemented HTTP methods for the endpoint here. | `OPTIONS, GET, POST, PATCH, PUT, DELETE` |
+    | Access-Control-Allow-Origin      | Allowed origin for the request, including protocol, host and port or `*` for all origins. It is RECOMMENDED to return the value `*` to allow requests from browser-based implementations such as the Web Editor. | `*` |
     | Access-Control-Expose-Headers    | Some endpoints send non-safelisted HTTP response headers such as `OpenEO-Identifier` and `OpenEO-Costs`. All headers except `Cache-Control`, `Content-Language`, `Content-Type`, `Expires`, `Last-Modified` and `Pragma` must be listed in this header. Currently, the openEO API requires at least the following headers to be listed: `Location, OpenEO-Identifier, OpenEO-Costs, Link`. | `Location, OpenEO-Identifier, OpenEO-Costs, Link` |
+    
+    
+    **Tip**: Most server can send the required headers and the responses to the OPTIONS requests globally. Otherwise you may want to use a proxy server to add the headers and OPTIONS responses.
+    
+    ### Example request and response
+    
+    Request:
+    
+    ```http
+    POST /api/v1/jobs HTTP/1.1
+    Host: openeo.cloudprovider.com
+    Origin: https://client.org:8080
+    Authorization: Bearer basic//ZXhhbXBsZTpleGFtcGxl
+    ```
+    
+    Response:
+    
+    ```http
+    HTTP/1.1 201 Created
+    Access-Control-Allow-Origin: *
+    Access-Control-Expose-Headers: Location, OpenEO-Identifier, OpenEO-Costs, Link
+    Content-Type: application/json
+    Location: https://openeo.cloudprovider.com/api/v1/jobs/abc123
+    OpenEO-Identifier: abc123
+    ```
+    
+    ## OPTIONS method
+    
+    All endpoints must respond to the `OPTIONS` HTTP method. This is a response for the preflight requests made by web browsers before sending the actual request (e.g. `POST /jobs`). It needs to respond with a status code of `204` and no response body. In addition to the HTTP headers shown in the table above, the following HTTP headers MUST be included with every response to an `OPTIONS` request:
+    
+    | Name                             | Description                                                  | Example |
+    | -------------------------------- | ------------------------------------------------------------ | ------- |
+    | Access-Control-Allow-Headers     | Comma-separated list of HTTP headers allowed to be send. MUST contain at least `Authorization` if any kind of authorization is implemented by the back-end. | `Authorization, Content-Type` |
+    | Access-Control-Allow-Methods     | Comma-separated list of HTTP methods allowed to be requested. Back-ends MUST list all implemented HTTP methods for the endpoint. | `OPTIONS, GET, POST, PATCH, PUT, DELETE` |
     | Content-Type                     | SHOULD return the content type delivered by the request that the permission is requested for. | `application/json` |
     
     ### Example request and response
@@ -159,7 +190,7 @@ info:
     ```http
     OPTIONS /api/v1/jobs HTTP/1.1
     Host: openeo.cloudprovider.com
-    Origin: http://client.org:8080
+    Origin: https://client.org:8080
     Access-Control-Request-Method: POST 
     Access-Control-Request-Headers: Authorization, Content-Type
     ```
@@ -168,25 +199,12 @@ info:
     
     ```http
     HTTP/1.1 204 No Content
-    Access-Control-Allow-Origin: http://client.org:8080
-    Access-Control-Allow-Credentials: true
+    Access-Control-Allow-Origin: *
     Access-Control-Allow-Methods: OPTIONS, GET, POST, PATCH, PUT, DELETE
     Access-Control-Allow-Headers: Authorization, Content-Type
+    Access-Control-Expose-Headers: Location, OpenEO-Identifier, OpenEO-Costs, Link
     Content-Type: application/json
     ```
-    
-    ## CORS headers
-    
-    The following headers MUST be included with every response:
-    
-    | Name                             | Description                                                  | Example |
-    | -------------------------------- | ------------------------------------------------------------ | ------- |
-    | Access-Control-Allow-Origin      | Allowed origin for the request, including protocol, host and port. It is RECOMMENDED to return the value of the request's origin header. If no `Origin` is sent to the back-end CORS headers SHOULD NOT be sent at all. | `http://client.isp.com:80` |
-    | Access-Control-Allow-Credentials | If authorization is implemented by the back-end the value MUST be `true`. | `true` |
-    | Access-Control-Expose-Headers    | Some endpoints send non-safelisted HTTP response headers such as `OpenEO-Identifier` and `OpenEO-Costs`. All headers except `Cache-Control`, `Content-Language`, `Content-Type`, `Expires`, `Last-Modified` and `Pragma` must be listed in this header. Currently, the openEO API requires at least the following headers to be listed: `Location, OpenEO-Identifier, OpenEO-Costs, Link`. | `Location, OpenEO-Identifier, OpenEO-Costs, Link` |
-    
-    
-    **Tip**: Most server can send the required headers and the responses to the OPTIONS requests globally. Otherwise you may want to use a proxy server to add the headers and OPTIONS responses.
 
     # Processes
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -148,7 +148,7 @@ info:
     | Name                             | Description                                                  | Example |
     | -------------------------------- | ------------------------------------------------------------ | ------- |
     | Access-Control-Allow-Origin      | Allowed origin for the request, including protocol, host and port or `*` for all origins. It is RECOMMENDED to return the value `*` to allow requests from browser-based implementations such as the Web Editor. | `*` |
-    | Access-Control-Expose-Headers    | In addition to the white-listed HTTP headers `Cache-Control`, `Content-Language`, `Content-Type`, `Expires`, `Last-Modified` and `Pragma`, some endpoints need to send additional HTTP response headers such as `OpenEO-Identifier`. All headers that should be made available to browser-based clients MUST be listed in this header. Currently, the openEO API requires at least the following headers to be listed: `Link`, `Location`, `OpenEO-Costs` and `OpenEO-Identifier`. | `Link, Location, OpenEO-Costs, OpenEO-Identifier` |
+    | Access-Control-Expose-Headers    | Some endpoints require to send additional HTTP response headers such as `OpenEO-Identifier` and `Location`. To make these headers available to browser-based clients, they MUST be white-listed with this CORS header. The following HTTP headers are white-listed by browsers and MUST NOT be included: `Cache-Control`, `Content-Language`, `Content-Length`, `Content-Type`, `Expires`, `Last-Modified` and `Pragma`. At least the following headers MUST be listed in this version of the openEO API: `Link`, `Location`, `OpenEO-Costs` and `OpenEO-Identifier`. | `Link, Location, OpenEO-Costs, OpenEO-Identifier` |
     
     
     


### PR DESCRIPTION
Changes with regards to how CORS headers are recommended to be sent. This came up in recent discussions in issue #41 and we realized the current recommendation could lead to security issues (although I don't think it could really be exploited with the current implementations). We figured out the current recommendation was based on a not very well written documentation regarding javascript HTTP request option withCredentials in axios / fetch / XHR. We don't need to provide the `Access-Control-Allow-Credentials` header and can set `Access-Control-Allow-Origin` to `*`. This blocks the potential security issues. I also tried to improve the descriptions around CORS a bit and provide an additional example request/response.

Seeing those changes I don't think this is a breaking change as the old implementations still work and are not invalid (but insecure). So it won't need to go through the PSC process, right? The only thing that will break is that v1.0.0 of the JS client won't be able to access v1.0.1 API back-ends, but JS client [v1.0.1](https://github.com/Open-EO/openeo-js-client/pull/38) will be integrated in all dependents even before the API is actually released.

Fixes #41