### PR TITLE
Multiple files returned by sync. processing #349

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `GET /processes` and `GET` / `PUT` for `/process_graphs/{process_graph_id}`: Allow specifying the return values processes receive from child processes. [#350](https://github.com/Open-EO/openeo-api/issues/350)
+- Recommendation that `POST /result` returns a `tar` file if the result consists of multiple files. [#349](https://github.com/Open-EO/openeo-api/issues/349)
 
 ### Changed
 
@@ -16,7 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Clarified how process exceptions should be used. [#352](https://github.com/Open-EO/openeo-api/issues/352)
-- Clarified that `POST /result` may return multiple files with a content type of `multipart/mixed`. [#349](https://github.com/Open-EO/openeo-api/issues/349)
 
 ## 1.0.1 - 2020-12-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Clarified how process exceptions should be used. [#352](https://github.com/Open-EO/openeo-api/issues/352)
+- Clarified that `POST /result` may return multiple files with a content type of `multipart/mixed`. [#349](https://github.com/Open-EO/openeo-api/issues/349)
 
 ## 1.0.1 - 2020-12-07
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1999,7 +1999,10 @@ paths:
             Content-Type:
               description: >-
                 The appropriate media (MIME) type for the requested output
-                format MUST be sent.
+                format MUST be sent, if the response contains a single file.
+                To send multiple files at once the media type MUST be
+                `multipart/mixed` with an appropriate response as defined
+                by [RFC 2046](https://www.rfc-editor.org/rfc/rfc2046.html).
               schema:
                 type: string
             OpenEO-Costs:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1997,12 +1997,19 @@ paths:
           description: Result data in the requested output format
           headers:
             Content-Type:
-              description: >-
+              description: |-
                 The appropriate media (MIME) type for the requested output
                 format MUST be sent, if the response contains a single file.
-                To send multiple files at once the media type MUST be
-                `multipart/mixed` with an appropriate response as defined
-                by [RFC 2046](https://www.rfc-editor.org/rfc/rfc2046.html).
+
+                To send multiple files at once it is RECOMMENDED to use the
+                [`tar` file format](https://www.gnu.org/software/tar/manual/html_node/Standard.html)
+                (media type: `application/x-tar`).
+                
+                To mimic the results of batch jobs, it is RECOMMENDED that 
+                1. clients extract the tar file directly after receiving it so that users
+                   can directly work on the contained files *and*
+                2. back-ends add STAC Items and/or Collections to the tar file
+                   so that users can make sense of the files.
               schema:
                 type: string
             OpenEO-Costs:


### PR DESCRIPTION
Clarified that `POST /result` may return multiple files as a tar. #349

This is potentially already allowed, at least there's no direct exclusion of the multipart media types, but none of the clients seem to really handle it.