### PR TITLE
Minor OpenID Connect `scopes` clarification

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1798,7 +1798,7 @@ paths:
                         scopes:
                           type: array
                           description: >-
-                            A list of OpenID Connect scopes that the client MUST use.
+                            A list of OpenID Connect scopes that the client MUST include when requesting authorization.
                             If scopes are specified, the list MUST at least contain the `openid` scope.
                           items:
                             type: string


### PR DESCRIPTION
Make generic "use" verb a bit more concrete