### PR TITLE
Add `default_client_id` to OpenID Connect provider data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `GET /processes` and `GET` / `PUT` for `/process_graphs/{process_graph_id}`: Allow specifying the return values processes receive from child processes. [#350](https://github.com/Open-EO/openeo-api/issues/350)
+- `GET /credentials/oidc` can provide a set of default client ids for OpenID Connect. [#366](https://github.com/Open-EO/openeo-api/pull/366)
 
 ### Changed
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1831,6 +1831,8 @@ paths:
 
                             The default OpenID Connect client is provided without availability guarantees.
                             The backend implementer CAN revoke, reset or update it any time.
+                            As such, openEO clients SHOULD NOT store or cache default OpenID Connect client information
+                            for long term usage.
                             The default OpenID Connect client is intended to simplify authentication for novice users.
                             For production use cases, it is RECOMMENDED to set up a dedicated OpenID Connect client.
                           required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1818,29 +1818,56 @@ paths:
 
                             [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich
                             text representation.
-                        default_client:
-                          title: Default OpenID Connect Client
-                          type: object
+                        default_clients:
+                          title: Default OpenID Connect Clients
+                          type: array
                           description: |-
-                            Default OpenID Connect client that can be used for OpenID Connect authentication.
+                            List of default OpenID Connect clients that can be used by an openEO client
+                            for OpenID Connect based authentication.
 
-                            The default OpenID Connect client is managed by the backend implementer.
+                            A default OpenID Connect client is managed by the backend implementer.
                             It MUST be configured to be usable without a client secret,
                             which limits its applicability to OpenID Connect grant types like
                             "Authorization Code Grant with PKCE" and "Device flow with PKCE"
 
-                            The default OpenID Connect client is provided without availability guarantees.
+                            A default OpenID Connect client is provided without availability guarantees.
                             The backend implementer CAN revoke, reset or update it any time.
                             As such, openEO clients SHOULD NOT store or cache default OpenID Connect client information
                             for long term usage.
-                            The default OpenID Connect client is intended to simplify authentication for novice users.
+                            A default OpenID Connect client is intended to simplify authentication for novice users.
                             For production use cases, it is RECOMMENDED to set up a dedicated OpenID Connect client.
-                          required:
-                            - id
-                          properties:
-                            id:
-                              type: string
-                              description: OpenID Connect client id
+                          items:
+                            title: Default OpenID Connect Client
+                            type: object
+                            required:
+                              - id
+                              - grant_types
+                            properties:
+                              id:
+                                type: string
+                                description: OpenID Connect client id
+                              grant_types:
+                                type: array
+                                description: |-
+                                  List of authorization flows (grant types) supported by the OpenID Connect client.
+                                  A flow descriptor consist of a OAuth 2.0 grant type,
+                                  with an additional `+pkce` suffix when the flow should be used with the PKCE extension.
+                                minItems: 1
+                                items:
+                                  type: string
+                                  enum:
+                                    - 'implicit'
+                                    - 'authorization_code+pkce'
+                                    - 'urn:ietf:params:oauth:grant-type:device_code+pkce'
+                                    - 'refresh_token'
+                              redirect_urls:
+                                type: array
+                                description: |-
+                                  List of redirect URLs that are whitelisted by the OpenID Connect client.
+                                  Redirect URLs MUST be provided when the OpenID Connect client supports
+                                  the `implicit` or `authorization_code+pkce` authorization flows.
+                                items:
+                                  type: string
                         links:
                           type: array
                           description: |-

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1828,7 +1828,7 @@ paths:
                             A default OpenID Connect client is managed by the backend implementer.
                             It MUST be configured to be usable without a client secret,
                             which limits its applicability to OpenID Connect grant types like
-                            "Authorization Code Grant with PKCE" and "Device flow with PKCE"
+                            "Authorization Code Grant with PKCE" and "Device Authorization Grant with PKCE"
 
                             A default OpenID Connect client is provided without availability guarantees.
                             The backend implementer CAN revoke, reset or update it any time.
@@ -1836,6 +1836,7 @@ paths:
                             for long term usage.
                             A default OpenID Connect client is intended to simplify authentication for novice users.
                             For production use cases, it is RECOMMENDED to set up a dedicated OpenID Connect client.
+                          uniqueItems: true
                           items:
                             title: Default OpenID Connect Client
                             type: object
@@ -1845,14 +1846,23 @@ paths:
                             properties:
                               id:
                                 type: string
-                                description: OpenID Connect client id
+                                description: >-
+                                  The OpenID Connect Client ID to be used in the authentication procedure.
                               grant_types:
                                 type: array
                                 description: |-
-                                  List of authorization flows (grant types) supported by the OpenID Connect client.
-                                  A flow descriptor consist of a OAuth 2.0 grant type,
-                                  with an additional `+pkce` suffix when the flow should be used with the PKCE extension.
+                                  List of authorization grant types (flows) supported by the OpenID Connect client.
+                                  A grant type descriptor consist of a OAuth 2.0 grant type,
+                                  with an additional `+pkce` suffix when the grant type should be used with
+                                  the PKCE extension as defined in [RFC 7636](https://www.rfc-editor.org/rfc/rfc7636.html).
+
+                                  Allowed values:
+                                  - `implicit`: Implicit Grant as specified in [RFC 6749, sec. 1.3.2](https://www.rfc-editor.org/rfc/rfc6749.html#section-1.3.2)
+                                  - `authorization_code+pkce`: Authorization Code Grant as specified in [RFC 6749, sec. 1.3.1](https://www.rfc-editor.org/rfc/rfc6749.html#section-1.3.1), with PKCE extension.
+                                  - `urn:ietf:params:oauth:grant-type:device_code+pkce`: Device Authorization Grant (aka Device Code Flow) as specified in [RFC 8628](https://www.rfc-editor.org/rfc/rfc8628.html), with PKCE extension.
+                                  - `refresh_token`: Refresh Token as specified in [RFC 6749, sec. 1.5](https://www.rfc-editor.org/rfc/rfc6749.html#section-1.5)
                                 minItems: 1
+                                uniqueItems: true
                                 items:
                                   type: string
                                   enum:
@@ -1866,8 +1876,10 @@ paths:
                                   List of redirect URLs that are whitelisted by the OpenID Connect client.
                                   Redirect URLs MUST be provided when the OpenID Connect client supports
                                   the `implicit` or `authorization_code+pkce` authorization flows.
+                                uniqueItems: true
                                 items:
                                   type: string
+                                  format: uri
                         links:
                           type: array
                           description: |-

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1859,7 +1859,7 @@ paths:
                                   Allowed values:
                                   - `implicit`: Implicit Grant as specified in [RFC 6749, sec. 1.3.2](https://www.rfc-editor.org/rfc/rfc6749.html#section-1.3.2)
                                   - `authorization_code+pkce`: Authorization Code Grant as specified in [RFC 6749, sec. 1.3.1](https://www.rfc-editor.org/rfc/rfc6749.html#section-1.3.1), with PKCE extension.
-                                  - `urn:ietf:params:oauth:grant-type:device_code+pkce`: Device Authorization Grant (aka Device Code Flow) as specified in [RFC 8628](https://www.rfc-editor.org/rfc/rfc8628.html), with PKCE extension.
+                                  - `urn:ietf:params:oauth:grant-type:device_code+pkce`: Device Authorization Grant (aka Device Code Flow) as specified in [RFC 8628](https://www.rfc-editor.org/rfc/rfc8628.html), with PKCE extension. Note that the combination of this grant with the PKCE extension is *not standardized* yet.
                                   - `refresh_token`: Refresh Token as specified in [RFC 6749, sec. 1.5](https://www.rfc-editor.org/rfc/rfc6749.html#section-1.5)
                                 minItems: 1
                                 uniqueItems: true

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1818,13 +1818,27 @@ paths:
 
                             [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich
                             text representation.
-                        default_client_id:
-                          type: string
+                        default_client:
+                          title: Default OpenID Connect Client
+                          type: object
                           description: |-
-                            Default client_id that clients can use for OpenID Connect authentication.
-                            The client MUST be usable without a secret, which limits the
-                            OAuth 2.0 Grant Flow options to "Authorization Code Grant with PKCE"
-                            and "Device flow with PKCE".
+                            Default OpenID Connect client that can be used for OpenID Connect authentication.
+
+                            The default OpenID Connect client is managed by the backend implementer.
+                            It MUST be configured to be usable without a client secret,
+                            which limits its applicability to OpenID Connect grant types like
+                            "Authorization Code Grant with PKCE" and "Device flow with PKCE"
+
+                            The default OpenID Connect client is provided without availability guarantees.
+                            The backend implementer CAN revoke, reset or update it any time.
+                            The default OpenID Connect client is intended to simplify authentication for novice users.
+                            For production use cases, it is RECOMMENDED to set up a dedicated OpenID Connect client.
+                          required:
+                            - id
+                          properties:
+                            id:
+                              type: string
+                              description: OpenID Connect client id
                         links:
                           type: array
                           description: |-

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1818,6 +1818,13 @@ paths:
 
                             [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich
                             text representation.
+                        default_client_id:
+                          type: string
+                          description: |-
+                            Default client_id that clients can use for OpenID Connect authentication.
+                            The client MUST be usable without a secret, which limits the
+                            OAuth 2.0 Grant Flow options to "Authorization Code Grant with PKCE"
+                            and "Device flow with PKCE".
                         links:
                           type: array
                           description: |-


### PR DESCRIPTION
First rough attempt to let backend pre-define a default OIDC client id, that openEO clients can use to streamline the OIDC authentication flow

discussion points and possible improvements:
- define a single `default_client_id` or allow multiple? I don't think there is a use case for multiple.
- other relevant information of OIDC client that could be relevant to openEO client? Most obvious example is  redirect URL whitelist for Authorization Code Grant.
- more instructions/constraints for backend provider about how to set up client?

to do:
- add changelog entry
