### PR TITLE
Make sure to use "OpenID Connect" in full instead of "OpenID"

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1714,7 +1714,7 @@ paths:
       operationId: authenticate-oidc
       description: >-
         Lists the supported [OpenID Connect](http://openid.net/connect/)
-        providers (OP). OpenID Providers MUST support [OpenID Connect
+        providers (OP). OpenID Connect Providers MUST support [OpenID Connect
         Discovery](http://openid.net/specs/openid-connect-discovery-1_0.html).
 
 
@@ -1725,9 +1725,9 @@ paths:
         openEO clients MUST use the **access token** as part of the Bearer token
         for authorization in subsequent API calls (see also the information
         about Bearer tokens in this document). Clients MUST NOT use the id token
-        or the authorization code. The access token provided by an OpenID
+        or the authorization code. The access token provided by an OpenID Connect
         Provider does not necessarily provide information about the issuer (i.e. the
-        OpenID provider) and therefore a prefix MUST be added to the Bearer
+        OpenID Connect provider) and therefore a prefix MUST be added to the Bearer
         Token sent in subsequent API calls to protected endpoints. The Bearer
         Token sent to protected endpoints MUST consist of the authentication
         method (here `oidc`), the provider ID and the access token itself. All
@@ -1736,25 +1736,25 @@ paths:
         endpoint.  The header in subsequent API calls for a provider with `id`
         `ms` would look as follows: `Authorization: Bearer oidc/ms/TOKEN`
         (replace `TOKEN` with the actual access token received from the OpenID
-        Provider).
+        Connect Provider).
 
 
         Back-ends MAY request user information ([including Claims](https://openid.net/specs/openid-connect-core-1_0.html#Claims))
         from the [OpenID Connect Userinfo endpoint](https://openid.net/specs/openid-connect-core-1_0.html#UserInfo)
         using the access token (without the prefix described above). Therefore,
         both openEO client and openEO back-end are relying parties (clients) to
-        the OpenID Provider.
+        the OpenID Connect Provider.
       tags:
         - Account Management
       security:
         - {}
       responses:
         '200':
-          description: Lists the the OpenID Providers.
+          description: Lists the the OpenID Connect Providers.
           content:
             application/json:
               schema:
-                title: OpenID Providers
+                title: OpenID Connect Providers
                 type: object
                 required:
                   - providers
@@ -1763,7 +1763,7 @@ paths:
                     type: array
                     minItems: 1
                     items:
-                      title: OpenID Provider
+                      title: OpenID Connect Provider
                       type: object
                       required:
                         - id
@@ -1773,7 +1773,7 @@ paths:
                         id:
                           type: string
                           description: >-
-                            A **unique** identifier for the OpenID Provider to
+                            A **unique** identifier for the OpenID Connect Provider to
                             be as prefix for the Bearer token.
                           pattern: '[\d\w]{1,20}'
                         issuer:
@@ -1782,12 +1782,12 @@ paths:
                           description: >-
                             The [issuer location](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig)
                             (also referred to as 'authority' in some client libraries) is the URL of the
-                            OpenID provider, which conforms to a set of rules:
+                            OpenID Connect provider, which conforms to a set of rules:
 
                             1. After appending `/.well-known/openid-configuration` to the URL, a
                             [HTTP/1.1 GET
                             request](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationRequest)
-                            to the concatenated URL MUST return a [OpenID Discovery Configuration
+                            to the concatenated URL MUST return a [OpenID Connect Discovery Configuration
                             Response](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationResponse).
                             The response provides all information required to authenticate using
                             OpenID Connect.
@@ -1806,7 +1806,7 @@ paths:
                           type: string
                           description: >-
                             The name that is publicly shown in clients for this
-                            OpenID provider.
+                            OpenID Connect provider.
                         description:
                           type: string
                           format: commonmark


### PR DESCRIPTION
It could be intentional, but I noticed that the docs use "OpenID provider" instead of "OpenID Connect provider".
Technically and practically these are not the same. I think we should use "OpenID Connect" in full wherever possible