### PR TITLE
Clarified case-insensitivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Clarified how process exceptions should be used. [#352](https://github.com/Open-EO/openeo-api/issues/352)
+- Clarified that billing plans, service names and file formats must be accepted case-insensitive. [#371](https://github.com/Open-EO/openeo-api/issues/371)
 - Fixed casing of potential endpoints `GET /collections/{collection_id}/items` and `GET /collections/{collection_id}/items/{feature_id}`.
 
 ## 1.0.1 - 2020-12-07

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -728,8 +728,8 @@ paths:
                             name:
                               type: string
                               description: >-
-                                Name of the plan. It MUST be accepted *case
-                                insensitive* throughout the API.
+                                Name of the plan. It MUST be accepted in a *case
+                                insensitive* manner throughout the API.
                               example: free
                             description:
                               type: string
@@ -975,7 +975,7 @@ paths:
         `title`.
 
 
-        Format names MUST be accepted *case insensitive* throughout the API.
+        Format names MUST be accepted in a *case insensitive* manner throughout the API.
       tags:
         - Capabilities
         - Data Processing
@@ -2239,7 +2239,7 @@ paths:
         [OGC Schema Repository](http://schemas.opengis.net/) for the respective
         services.
 
-        Service names MUST be accepted *case insensitive* throughout the API.
+        Service names MUST be accepted in a *case insensitive* manner throughout the API.
       tags:
         - Capabilities
         - Secondary Services
@@ -3815,7 +3815,7 @@ components:
       description: |-
         The billing plan to process and charge the job or service with.
 
-        Billing plans MUST be accepted *case insensitive*.
+        Billing plans MUST be accepted in a *case insensitive* manner.
         
         The plans can be retrieved from `GET /`, but the value returned here may
         not be in the list of plans any longer.
@@ -3825,10 +3825,10 @@ components:
       description: |-
         The billing plan to process and charge the job or service with.
 
-        Billing plans MUST be accepted *case insensitive*. If `null` is specified
-        by the client explicitly, the server MUST store the default plan and
-        persist it regardless of any changes to the default billing plan in the
-        future.
+        Billing plans MUST be accepted in a *case insensitive* manner. If `null`
+        is specified by the client explicitly, the server MUST store the default
+        plan and persist it regardless of any changes to the default billing plan
+        in the future.
 
         The list of plans and the default plan can be retrieved from `GET /`.
         Billing plans not on the list of available plans MUST be rejected with
@@ -3840,8 +3840,8 @@ components:
       description: |-
         The billing plan to process and charge the job or service with.
 
-        Billing plans MUST be accepted *case insensitive*. If `null` is given
-        implicitly (through the default value) or explicitly by the client,
+        Billing plans MUST be accepted in a *case insensitive* manner. If `null`
+        is given implicitly (through the default value) or explicitly by the client,
         the server MUST store the default plan and persist it regardless of any
         changes to the default billing plan in the future.
 
@@ -5167,7 +5167,7 @@ components:
       description: >-
         Definition of the service type to access result data. All available
         service types can be retrieved via `GET /service_types`. Service types
-        MUST be accepted *case insensitive*.
+        MUST be accepted in a *case insensitive* manner.
       type: string
       example: wms
     service_configuration:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -712,8 +712,7 @@ paths:
                         type: string
                         description: >-
                           Name of the default plan to use when the user doesn't
-                          specify a plan. Is allowed to be *case insensitive*
-                          throughout the API.
+                          specify a plan.
                         example: free
                       plans:
                         description: Array of plans
@@ -729,7 +728,7 @@ paths:
                             name:
                               type: string
                               description: >-
-                                Name of the plan. Is allowed to be *case
+                                Name of the plan. It MUST be accepted *case
                                 insensitive* throughout the API.
                               example: free
                             description:
@@ -976,7 +975,7 @@ paths:
         `title`.
 
 
-        Format names are allowed to be *case insensitive* throughout the API.
+        Format names MUST be accepted *case insensitive* throughout the API.
       tags:
         - Capabilities
         - Data Processing
@@ -2240,7 +2239,7 @@ paths:
         [OGC Schema Repository](http://schemas.opengis.net/) for the respective
         services.
 
-        Service names are allowed to be *case insensitive* throughout the API.
+        Service names MUST be accepted *case insensitive* throughout the API.
       tags:
         - Capabilities
         - Secondary Services
@@ -3816,7 +3815,7 @@ components:
       description: |-
         The billing plan to process and charge the job or service with.
 
-        Billing plans are allowed to be *case insensitive*.
+        Billing plans MUST be accepted *case insensitive*.
         
         The plans can be retrieved from `GET /`, but the value returned here may
         not be in the list of plans any longer.


### PR DESCRIPTION
Clarified that billing plans, service names and file formats must be accepted case-insensitive. #371