### PR TITLE
Support a default provider for OIDC + new example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `GET /processes` and `GET` / `PUT` for `/process_graphs/{process_graph_id}`: Allow specifying the return values processes receive from child processes. [#350](https://github.com/Open-EO/openeo-api/issues/350)
 - `GET /credentials/oidc` can provide a set of default client ids for OpenID Connect. [#366](https://github.com/Open-EO/openeo-api/pull/366)
+- `GET /credentials/oidc` can specify a default provider for OpenID Connect.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `GET /processes` and `GET` / `PUT` for `/process_graphs/{process_graph_id}`: Allow specifying the return values processes receive from child processes. [#350](https://github.com/Open-EO/openeo-api/issues/350)
 - `GET /credentials/oidc` can provide a set of default client ids for OpenID Connect. [#366](https://github.com/Open-EO/openeo-api/pull/366)
-- `GET /credentials/oidc` can specify a default provider for OpenID Connect.
 
 ### Changed
 
@@ -19,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Clarified how process exceptions should be used. [#352](https://github.com/Open-EO/openeo-api/issues/352)
 - Clarified that billing plans, service names and file formats must be accepted case-insensitive. [#371](https://github.com/Open-EO/openeo-api/issues/371)
+- Clarified that the first provider listed at `GET /credentials/oidc` is the default provider for OpenID Connect.
 - Fixed casing of potential endpoints `GET /collections/{collection_id}/items` and `GET /collections/{collection_id}/items/{feature_id}`.
 
 ## 1.0.1 - 2020-12-07

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1817,6 +1817,15 @@ paths:
 
                             [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich
                             text representation.
+                        default:
+                          type: boolean
+                          default: false
+                          description: |-
+                            One of the OpenID Connect providers can be made the default provider
+                            for authentication by setting this option to `true`.
+
+                            Clients can either pre-select or directly use the default provider for authentication
+                            if the user doesn't specify a specific value.
                         default_clients:
                           title: Default OpenID Connect Clients
                           type: array
@@ -1891,6 +1900,24 @@ paths:
                             $ref: '#/components/schemas/link'
               example:
                 providers:
+                  - id: egi
+                    issuer: 'https://aai.egi.eu/oidc'
+                    title: EGI
+                    description: Login with your academic account.
+                    default: true
+                    scopes:
+                      - openid
+                      - profile
+                      - email
+                    default_clients:
+                      - id: KStcUzD5AIUA
+                        grant_types:
+                          - implicit
+                          - authorization_code+pkce
+                          - urn:ietf:params:oauth:grant-type:device_code+pkce
+                          - refresh_token
+                        redirect_urls:
+                          - https://editor.openeo.org/
                   - id: google
                     issuer: 'https://accounts.google.com'
                     title: Google

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1711,15 +1711,13 @@ paths:
     get:
       summary: OpenID Connect authentication
       operationId: authenticate-oidc
-      description: >-
+      description: |-
         Lists the supported [OpenID Connect](http://openid.net/connect/)
         providers (OP). OpenID Connect Providers MUST support [OpenID Connect
         Discovery](http://openid.net/specs/openid-connect-discovery-1_0.html).
 
-
         It is highly RECOMMENDED to implement OpenID Connect for public services
         in favor of Basic authentication.
-
 
         openEO clients MUST use the **access token** as part of the Bearer token
         for authorization in subsequent API calls (see also the information
@@ -1736,7 +1734,6 @@ paths:
         `ms` would look as follows: `Authorization: Bearer oidc/ms/TOKEN`
         (replace `TOKEN` with the actual access token received from the OpenID
         Connect Provider).
-
 
         Back-ends MAY request user information ([including Claims](https://openid.net/specs/openid-connect-core-1_0.html#Claims))
         from the [OpenID Connect Userinfo endpoint](https://openid.net/specs/openid-connect-core-1_0.html#UserInfo)
@@ -1760,6 +1757,10 @@ paths:
                 properties:
                   providers:
                     type: array
+                    description: >-
+                      The first provider in this list is the default provider for authentication.
+                      Clients can either pre-select or directly use the default provider for authentication
+                      if the user doesn't specify a specific value.
                     minItems: 1
                     items:
                       title: OpenID Connect Provider
@@ -1817,15 +1818,6 @@ paths:
 
                             [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich
                             text representation.
-                        default:
-                          type: boolean
-                          default: false
-                          description: |-
-                            One of the OpenID Connect providers can be made the default provider
-                            for authentication by setting this option to `true`.
-
-                            Clients can either pre-select or directly use the default provider for authentication
-                            if the user doesn't specify a specific value.
                         default_clients:
                           title: Default OpenID Connect Clients
                           type: array
@@ -1902,9 +1894,8 @@ paths:
                 providers:
                   - id: egi
                     issuer: 'https://aai.egi.eu/oidc'
-                    title: EGI
+                    title: EGI (default)
                     description: Login with your academic account.
-                    default: true
                     scopes:
                       - openid
                       - profile


### PR DESCRIPTION
- Support a default client for OIDC
- Added a new example, also showing the default_clients