### PR TITLE
Clarified allowed characters in the `path` for uploaded user files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Clarified that the first provider listed at `GET /credentials/oidc` is the default provider for OpenID Connect.
 - Clarified that `GET /jobs/{job_id}/results` should always return valid signed URLs and the endpoint can be used to renew the signed URLs. [#379](https://github.com/Open-EO/openeo-api/issues/379)
 - Fixed casing of potential endpoints `GET /collections/{collection_id}/items` and `GET /collections/{collection_id}/items/{feature_id}`.
+- Clarified allowed characters in the `path` for uploaded user files.
 
 ## 1.0.1 - 2020-12-07
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5524,10 +5524,17 @@ components:
       properties:
         path:
           type: string
-          description: >-
-            Path of the file, relative to the user's root directory. MUST NOT
-            start with a slash and MUST NOT be url-encoded.
+          description: |-
+            Path of the file, relative to the root directory of the user's server-side workspace.
+            MUST NOT start with a slash `/` and MUST NOT be url-encoded.
+
+            The Windows-style path name component separator `\` is not supported,
+            always use `/` instead.
+
+            Note: The pattern only specifies a minimal subset of invalid characters.
+            The back-ends MAY enforce additional restrictions depending on their OS/environment.
           example: folder/file.txt
+          pattern: "^[^/\r\n\\:'\"][^\r\n\\:'\"]*$"
         size:
           type: integer
           description: File size in bytes.


### PR DESCRIPTION
Clarified allowed characters in the `path` for uploaded user files, related to a PR I'll issue soon in processes.

Although this is a "new restriction" in the API, I'd argue this is non-breaking as no OS I'm aware of allows those characters anyway and thus files paths containing such characters would be rejected anyway.