### PR TITLE
OIDC: Allow auth code flow and device flow for default clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `create-form` to link to the registration page
   - `recovery-form` to link to the credentials recovery page.
 - `GET /me`: New Relation types `alternate` and `related` for user-specific external pages. [#404](https://github.com/Open-EO/openeo-api/issues/404)
+- `GET /credentials/oids`: Allow `authorization_code` and `urn:ietf:params:oauth:grant-type:device_code` (both without PKCE) as grants for `default_clients`. [#410](https://github.com/Open-EO/openeo-api/issues/410)
 - Recommendation to add media types and titles to links for a better user experience.
 - Allow the relation type `canonical` to be used generally for (shared) resources (e.g. UDPs or batch jobs) without requiring Bearer authentication. [#405](https://github.com/Open-EO/openeo-api/issues/405)
 - Recommendation for UDF runtime names. [#409](https://github.com/Open-EO/openeo-api/issues/409)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1897,8 +1897,8 @@ paths:
 
                                   Allowed values:
                                   - `implicit`: Implicit Grant as specified in [RFC 6749, sec. 1.3.2](https://www.rfc-editor.org/rfc/rfc6749.html#section-1.3.2)
-                                  - `authorization_code+pkce`: Authorization Code Grant as specified in [RFC 6749, sec. 1.3.1](https://www.rfc-editor.org/rfc/rfc6749.html#section-1.3.1), with PKCE extension.
-                                  - `urn:ietf:params:oauth:grant-type:device_code+pkce`: Device Authorization Grant (aka Device Code Flow) as specified in [RFC 8628](https://www.rfc-editor.org/rfc/rfc8628.html), with PKCE extension. Note that the combination of this grant with the PKCE extension is *not standardized* yet.
+                                  - `authorization_code` / `authorization_code+pkce`: Authorization Code Grant as specified in [RFC 6749, sec. 1.3.1](https://www.rfc-editor.org/rfc/rfc6749.html#section-1.3.1), with or without PKCE extension.
+                                  - `urn:ietf:params:oauth:grant-type:device_code` / `urn:ietf:params:oauth:grant-type:device_code+pkce`: Device Authorization Grant (aka Device Code Flow) as specified in [RFC 8628](https://www.rfc-editor.org/rfc/rfc8628.html), with or without PKCE extension. Note that the combination of this grant with the PKCE extension is *not standardized* yet.
                                   - `refresh_token`: Refresh Token as specified in [RFC 6749, sec. 1.5](https://www.rfc-editor.org/rfc/rfc6749.html#section-1.5)
                                 minItems: 1
                                 uniqueItems: true
@@ -1906,7 +1906,9 @@ paths:
                                   type: string
                                   enum:
                                     - 'implicit'
+                                    - 'authorization_code'
                                     - 'authorization_code+pkce'
+                                    - 'urn:ietf:params:oauth:grant-type:device_code'
                                     - 'urn:ietf:params:oauth:grant-type:device_code+pkce'
                                     - 'refresh_token'
                               redirect_urls:
@@ -1914,7 +1916,7 @@ paths:
                                 description: |-
                                   List of redirect URLs that are whitelisted by the OpenID Connect client.
                                   Redirect URLs MUST be provided when the OpenID Connect client supports
-                                  the `implicit` or `authorization_code+pkce` authorization flows.
+                                  the Implicit Grant or the Authorization Code Grant (with or without PKCE extension).
                                 uniqueItems: true
                                 items:
                                   type: string


### PR DESCRIPTION
Fixes/Implements #410.

Could someone verify that my understanding of the authorization_code flow is correct and doesn't require a client_secret?