### PR TITLE
Relax requirement to use HTTP 501 #415

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated STAC specification examples and references to v1.0.0.
+- Relaxed requirement that unsupported endpoints must return HTTP status code 501. Instead also HTTP status code 404 can be used (and is regularly used in practice). [#415](https://github.com/Open-EO/openeo-api/issues/415)
 
 ### Fixed
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -112,10 +112,14 @@ info:
 
     - **404 Not Found**:
       The resource specified by the path does not exist, i.e. one of the resources belonging to the specified identifiers are not available at the back-end.
-      *Note:* Unsupported endpoints MUST use HTTP status code 501.
+      *Note:* Unsupported endpoints MAY also return HTTP status code 501.
 
     - **500 Internal Server Error**:
       The error has its origin on server side and no other status code in the 500 range is suitable.
+
+    - **501 Not Implemented**:
+      The requested endpoint is specified by the openEO API, but is not implemented (yet) by the back-end.
+      *Note:* Unsupported endpoints MAY also return HTTP status code 404.
 
 
     If a HTTP status code in the 400 range is returned, the client SHOULD NOT repeat the request without modifications. For HTTP status code in the 500 range, the client MAY repeat the same request later.


### PR DESCRIPTION
See issue #415 for details.

Strictly speaking, this is a breaking change, but in reality, all clients (afaik) handle 404 well enough as most back-ends return 404s instead of 501s for unsupported back-ends. Therefore a check from all client devs (Py, R, JS) would be appreciated.

- [ ] R Client
- [x] JS Client
- [ ] Python Client