### PR TITLE
Upgrade to Spectral v6

### DIFF
--- a/.spectral.yml
+++ b/.spectral.yml
@@ -6,7 +6,7 @@ except:
 rules:
   contact-properties: true
   tag-description: true
-# oas3-parameter-description: true # Broken: https://github.com/stoplightio/spectral/issues/1971
+  oas3-parameter-description: true
   oas3-unused-component: false # Broken: https://github.com/stoplightio/spectral/issues/1271
   operation-summary-formatted:
     description: Operation `summary` should start with upper case and not end with a dot.

--- a/.spectral.yml
+++ b/.spectral.yml
@@ -1,27 +1,15 @@
 extends: "spectral:oas"
-# don't error on circular schemas, these are currently not supported by spectral
-# https://github.com/stoplightio/spectral/issues/894
+# Work around broken rules: https://github.com/stoplightio/spectral/issues/1972
 except:
-  "openapi.yaml#/components/schemas/process_graph/example":
+  "openapi.yaml#/paths/~1udf_runtimes/get/responses/200/content/application~1json/example":
     - oas3-valid-schema-example
-  "openapi.yaml#/paths/~1processes/get/responses/200/content/application~1json/example":
-    - oas3-valid-oas-content-example
-  "openapi.yaml#/paths/~1process_graphs/get/responses/200/content/application~1json/example":
-    - oas3-valid-oas-content-example
-  "openapi.yaml#/paths/~1service_types/get/responses/200/content/application~1json/example":
-    - oas3-valid-oas-content-example
-  "openapi.yaml#/paths/~1file_formats/get/responses/200/content/application~1json/example":
-    - oas3-valid-oas-content-example
 rules:
-  # Ported from Spectral 4.0
   contact-properties: true
   tag-description: true
-  oas3-parameter-description: true
-  oas3-unused-components-schema: false # Broken: https://github.com/stoplightio/spectral/issues/1271
+# oas3-parameter-description: true # Broken: https://github.com/stoplightio/spectral/issues/1971
+  oas3-unused-component: false # Broken: https://github.com/stoplightio/spectral/issues/1271
   operation-summary-formatted:
     description: Operation `summary` should start with upper case and not end with a dot.
-    recommended: true
-    type: style
     given: '$.paths.*[?( @property === ''get'' || @property === ''put'' || @property === ''post'' || @property === ''delete'' || @property === ''options'' || @property === ''head'' || @property === ''patch'' || @property === ''trace'' )]'
     then:
       field: summary
@@ -31,7 +19,7 @@ rules:
     tags:
       - operation
   operation-id-kebab-case:
-    given: "$"
+    given: "$..operationId"
     then:
       function: pattern
       functionOptions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `GET /me`: Clarify the behavior of the field `budget`.
 - `GET /jobs/{job_id}/logs`, `GET /services/{service_id}/logs` and `POST /result`: Clarified the formatting of the `message` property. [#455](https://github.com/Open-EO/openeo-api/issues/455)
 - `GET /jobs/{job_id}/estimate`: Don't require that the costs are the upper limit. Services may specify the costs more freely depending on their terms of service.
+- Several appearances of `nullable` were clarified according to the lint report by Spectral
 
 ## [1.1.0] - 2021-05-17
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1077,7 +1077,7 @@ paths:
                       compress:
                         type: string
                         description: Set the compression to use.
-                        default: none
+                        default: NONE
                         enum:
                           - JPEG
                           - LZW
@@ -5024,7 +5024,7 @@ components:
               arguments:
                 $ref: '#/components/schemas/process_arguments'
               returns:
-                nullable: true
+                description: The return value which can by of any data type.
         links:
           type: array
           description: >-
@@ -5056,12 +5056,16 @@ components:
         - id
       properties:
         summary:
+          type: string
           nullable: true
         description:
+          type: string
           nullable: true
         parameters:
+          type: array
           nullable: true
         returns:
+          type: object
           nullable: true
       allOf:
         - $ref: '#/components/schemas/process'
@@ -5073,14 +5077,19 @@ components:
         - process_graph
       properties:
         id:
+          type: string
           nullable: true
         summary:
+          type: string
           nullable: true
         description:
+          type: string
           nullable: true
         parameters:
+          type: array
           nullable: true
         returns:
+          type: object
           nullable: true
       allOf:
         - $ref: '#/components/schemas/process'
@@ -5255,7 +5264,6 @@ components:
           description: >-
             The default value for this parameter.
             Required parameters SHOULD NOT specify a default value. Optional parameters SHOULD always specify a default value.
-          nullable: true
     parameter:
       title: Parameter
       type: object
@@ -5557,7 +5565,6 @@ components:
             value MUST conform to the defined type for the parameter defined at
             the same level. For example, if type is string, then default can be
             "foo" but cannot be 1. See [JSON Schema draft-07](https://json-schema.org/draft-07/json-schema-validation.html#rfc.section.10.2).
-          nullable: true
       allOf:
         - $ref: '#/components/schemas/json_schema'
     error:
@@ -5950,7 +5957,6 @@ components:
 
             For example, a raster-cube passed to the `debug` SHOULD return the
             metadata similar to the collection metadata, including `cube:dimensions`.
-          nullable: true
         path:
           description: |-
             Describes where the log entry originates from.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "git+https://github.com/Open-EO/openeo-api.git"
   },
   "devDependencies": {
-    "@stoplight/spectral-cli": "^6.1.0",
+    "@stoplight/spectral-cli": "^6.6.0",
     "redoc-cli": "^0.13.18"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "url": "git+https://github.com/Open-EO/openeo-api.git"
   },
   "devDependencies": {
-    "@stoplight/spectral": "^5.9.1",
-    "redoc-cli": "0.10.1"
+    "@stoplight/spectral-cli": "^6.1.0",
+    "redoc-cli": "^0.13.1"
   },
   "scripts": {
     "start": "redoc-cli serve openapi.yaml --watch --options.expandResponses \"200,201,202,203,204\" --options.pathInMiddlePanel true",


### PR DESCRIPTION
Related issues:
- https://github.com/stoplightio/spectral/issues/1972
- https://github.com/stoplightio/spectral/issues/1971
- https://github.com/stoplightio/spectral/issues/1271

And fix some issues in the OpenAPI file that have been reported by Spectral v6.