### PR TITLE
Update broken links to file format GDAL codes

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -962,8 +962,8 @@ paths:
 
         **Note**: Format names and parameters MUST be fully aligned with the
         GDAL codes if available, see [GDAL Raster
-        Formats](http://www.gdal.org/formats_list.html) and [OGR Vector
-        Formats](http://www.gdal.org/ogr_formats.html). It is OPTIONAL to
+        Formats](https://gdal.org/drivers/raster/index.html) and [OGR Vector
+        Formats](https://gdal.org/drivers/vector/index.html). It is OPTIONAL to
         support all output format parameters supported by GDAL. Some file
         formats not available through GDAL may be defined centrally for openEO.
         Custom file formats or parameters MAY be defined.


### PR DESCRIPTION
http://www.gdal.org/formats_list.html  and https://gdal.org/ogr_formats.html  give 404 