### PR TITLE
Conformance classes / OGC API and STAC API alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Relaxed requirement that unsupported endpoints must return HTTP status code 501. Instead also HTTP status code 404 can be used (and is regularly used in practice). [#415](https://github.com/Open-EO/openeo-api/issues/415)
 - Minimum value for `costs` and `budget` is 0.
 - `GET /jobs/{job_id}/estimate`: If a batch job can't be estimated reliably, a `EstimateComplexity` error should be returned. [#443](https://github.com/Open-EO/openeo-api/issues/443)
-- The `/conformance` endpoints is now generally used for OGC APIs, STAC API and openEO. All openEO and all extensions got individual conformance classes. [#186](https://github.com/Open-EO/openeo-api/issues/186)
+- The `/conformance` endpoint is now generally used for OGC APIs, STAC API and openEO. All openEO and all extensions got individual conformance classes. [#186](https://github.com/Open-EO/openeo-api/issues/186)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Relaxed requirement that unsupported endpoints must return HTTP status code 501. Instead also HTTP status code 404 can be used (and is regularly used in practice). [#415](https://github.com/Open-EO/openeo-api/issues/415)
 - Minimum value for `costs` and `budget` is 0.
 - `GET /jobs/{job_id}/estimate`: If a batch job can't be estimated reliably, a `EstimateComplexity` error should be returned. [#443](https://github.com/Open-EO/openeo-api/issues/443)
+- The `/conformance` endpoints is now generally used for OGC APIs, STAC API and openEO. All openEO and all extensions got individual conformance classes. [#186](https://github.com/Open-EO/openeo-api/issues/186)
 
 ### Fixed
 

--- a/extensions/commercial-data/README.md
+++ b/extensions/commercial-data/README.md
@@ -5,6 +5,7 @@ The Commercial Data API extension provides an interface for discovering, orderin
 - Version: **0.1.0**
 - Stability: **experimental**
 - [OpenAPI document](openapi.yaml)
+- Conformance class: `https://api.openeo.org/extensions/commercial-data/0.1.0`
 
 **Note:** This document only documents the additions to the specification.
 Extensions can not change or break existing behavior of the openEO API.

--- a/extensions/federation/README.md
+++ b/extensions/federation/README.md
@@ -6,6 +6,7 @@ This is an extension for federation aspects, i.e. where multiple back-ends are e
 
 - Version: **0.1.0**
 - Stability: **experimental**
+- Conformance class: `https://api.openeo.org/extensions/federation/0.1.0`
 
 **Note:** This document only documents the additions to the specification.
 Extensions can not change or break existing behavior of the openEO API.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1157,14 +1157,22 @@ paths:
           $ref: '#/components/responses/server_error'
   /conformance:
     get:
-      summary: OGC specifications this API conforms to
+      summary: Conformance classes this API implements
       operationId: conformance
-      description: >-
-        Lists all conformance classes specified in OGC standards that the
-        server conforms to.
+      description: |-
+        Lists all conformance classes specified in various standards that the
+        implementation conforms to. Conformance classes are commonly used in
+        all OGC APIs and the STAC API specification. openEO adds relatively
+        broadly defined conformance classes, especially for the extensions.
+        Otherwise, the implemented functionality can usually be retrieved from
+        the [capabilties](#tag/Capabilities/operation/capabilities) in openEO.
 
-        This endpoint is only required if full compliance with OGC API standards is desired.
-        Therefore, openEO back-ends MAY implement it for compatibility with OGC API clients and openEO clients don't need to request it.
+        The general openEO conformance class is `https://api.openeo.org/1.1.0`.
+        See the individual extensions for their conformance classes.
+
+        More details:
+        - [STAC API](https://github.com/radiantearth/stac-api-spec), especially "STAC API - Collections and Features Specification"
+        - [OGC APIs](https://ogcapi.ogc.org/)
       tags:
         - Capabilities
       responses:
@@ -1186,7 +1194,10 @@ paths:
                       example: http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core
               example:
                 conformsTo:
-                  - 'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core'
+                  - https://api.openeo.org/1.1.0
+                  - https://api.openeo.org/extensions/commercial-data/0.1.0
+                  - https://api.openeo.org/extensions/federation/0.1.0
+                  - https://api.stacspec.org/v1.0.0-rc.2/collections
         5XX:
           $ref: '#/components/responses/server_error'
   /collections:


### PR DESCRIPTION
Partially implements #186

The `/conformance` endpoints is now generally used for OGC APIs, STAC API and openEO. All openEO and all extensions got individual conformance classes. #186

This will become useful when we submit the openEO API to OGC as community standard.