### PR TITLE
Issue #507: clarify that "canonical" job result link should include query parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `GET /file_formats`: Base paramater on top of normal JSON Schema, not Process JSON Schema
 - `PATCH /services/{service_id}` and `PATCH /jobs/{job_id}`: Explicitly allow updating back-end specific properties (as in `POST`)
 - `GET /services/{service_id}` and `GET /jobs/{job_id}`: Explicitly allow listing back-end specific properties (as provided in `POST`)
+- `GET /jobs/{job_id}/results`: Clarify that "canonical" job result link should include query parameters
 
 ## [1.2.0] - 2021-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `GET /file_formats`: Base parameter on top of normal JSON Schema, not Process JSON Schema
 - `PATCH /services/{service_id}` and `PATCH /jobs/{job_id}`: Explicitly allow updating back-end specific properties (as in `POST`)
 - `GET /services/{service_id}` and `GET /jobs/{job_id}`: Explicitly allow listing back-end specific properties (as provided in `POST`)
-- `GET /jobs/{job_id}/results`: Clarify that "canonical" job result link should include query parameters
 - `GET /jobs/{job_id}/results`: Clarify that signed URLs (used as "canonical" link) should be regenerated each time.
 - Clarified for log levels which default values apply
 - Clarified how the relation types `license`, `version-history` and `author` can be used to enrich the process metadata. [#531](https://github.com/Open-EO/openeo-api/issues/531)
 - Clarified the behaviour of `federation:backends` for `POST /validation`
+- `GET /jobs/{job_id}/results`: Clarify that "canonical" job result link should include/encode the original query parameters
 
 ## [1.2.0] - 2021-05-25
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4031,7 +4031,9 @@ components:
             default.
 
             It is **strongly recommended** to add a link with relation type
-            `canonical`, which points to this STAC document using a signed URL.
+            `canonical`, which points to this STAC document
+            (including all query parameters like `partial`)
+            using a signed URL.
             This way the STAC metadata can be used by non-openEO clients
             without additional authentication steps.
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4039,8 +4039,10 @@ components:
             default.
 
             It is **strongly recommended** to add a link with relation type
-            `canonical` pointing to this STAC document using a signed URL
-            (including all query parameters like `partial`).
+            `canonical` pointing to this STAC document using a signed URL.
+            Note that query parameters that influence the response of the current request
+            (like `partial`) MUST also be included or encoded within the signed URL
+            in order to give a consistent response when the signed URL is used.
             This signed URL allows consumption of the STAC metadata
             by (possibly non-openEO) clients and tools
             without additional authentication steps.


### PR DESCRIPTION
Issue #507: clarify that "canonical" job result link should include query parameters