### PR TITLE
Have maximum length on workspace_id

### DIFF
--- a/extensions/workspaces/openapi.yaml
+++ b/extensions/workspaces/openapi.yaml
@@ -301,7 +301,7 @@ components:
   schemas:
     workspace_id:
       type: string
-      pattern: '^[A-Za-z0-9][\w\-\.~]{0,62}$' 
+      pattern: '^[a-z0-9][a-z0-9\-]{0,62}$' 
       example: my-workspace
     workspace_title:
       type: string

--- a/extensions/workspaces/openapi.yaml
+++ b/extensions/workspaces/openapi.yaml
@@ -301,7 +301,7 @@ components:
   schemas:
     workspace_id:
       type: string
-      pattern: '^[\w\-\.~]+$'
+      pattern: '^[A-Za-z0-9][\w\-\.~]{0,62}$' 
       example: my-workspace
     workspace_title:
       type: string


### PR DESCRIPTION
This helps applications to not make assumptions that are false. 63 characters is a common limit for naming (e.g. DNS parts) that is not very restrictive for users/use-cases. In most cases special characters are not allowed at the start of identifiers.

By having these constraints implementations can make assumptions and do bounds checking and it is easier to map workspace_id's to other resources that might impose similar constraints.

@m-mohr I am not sure if there is a specific reason for including a tilde-symbol if not I'd have a slight preference to not include that one either given that it is not common for naming and could also not be available for other resources that one might want to create as part of their workspace implementation. 