### PR TITLE
doc: use AWS vocabulary in AWS example

### DIFF
--- a/extensions/workspaces/openapi.yaml
+++ b/extensions/workspaces/openapi.yaml
@@ -114,15 +114,19 @@ paths:
                     title: Amazon S3
                     description: >-
                       Amazon S3 is a cloud storage service provided by Amazon Web Services.
+                      It provides storage containers which are called buckets.
                     intents:
                       - create
                       - register
                     parameters:
-                      username:
-                        title: Username
+                      aws_access_key_id:
+                        title: AWS access key
                         type: string
-                      password:
-                        title: Password
+                      aws_secret_access_key:
+                        title: AWS secret key associated with the access key.
+                        type: string
+                      bucket_name:
+                        title: Bucket name
                         type: string
                     links: []    
   /workspaces:
@@ -374,13 +378,14 @@ components:
     workspace_parameters:
       type: object
       description: >-
-        Additional parameters to register the workspace as defined in `GET /workspace_types`.
+        Additional parameters to register the workspace as defined in `GET /workspace_providers`.
         The structure is not specified by the API.
       additionalProperties:
         description: Any type
       example:
-        username: john_doe
-        password: secret123
+        aws_access_key_id: AKIAI0A0FAKE0EXAMPLE
+        aws_secret_access_key: TheKey1CorrespondingtoAccessKey.
+        bucket_name: my-bucket123
     workspace_properties:
       type: object
       description: >-


### PR DESCRIPTION
When using AWS S3 buckets (provided by AWS or by another S3-compliant provider) in most cases access is not controlled using username & password combination but instead an aws_access_key_id & aws_secret_access_key (optionally an aws_session_token).

There is also a small typo in the description for workspace_parameters.

If the bucket name is meant to be chosen by the workspace provider then I can adapt the example. In that case I guess it would  make sense to have the workspace_properties example adapted to show the bucket name as a metadata that comes from the workspace provider. Because region is unlikely a dynamic choice that is done per workspace by the workspace provider it would either be an input parameter provided by the user or a workspace provider that is tied to a region such that the platform has 1 workspace provider per supported region. As I am not clear on intent here I didn´t do further change there.