### PR TITLE
Federation extension: nullable last_successful_check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Clarified how the relation types `license`, `version-history` and `author` can be used to enrich the process metadata. [#531](https://github.com/Open-EO/openeo-api/issues/531)
 - Clarified the behaviour of `federation:backends` for `POST /validation`
 - Clarified the meaning of `expires` in batch job results
+- Clarified that `last_successful_check` (from Federation Extension) can be null.
 
 ## [1.2.0] - 2021-05-25
 

--- a/extensions/federation/README.md
+++ b/extensions/federation/README.md
@@ -59,10 +59,13 @@ schema:
             format: date-time
             description: The time at which the status of the back-end was checked last.
           last_successful_check:
-            type: string
-            format: date-time
+            type:
+              - type: string
+                format: date-time
+              - type: null
             description: >-
-              If the `status` is `offline`: The time at which the back-end was checked and available the last time.
+              If the `status` is `offline`: The time at which the back-end was checked and available the last time
+              or `null` when the back-end was never observed to be available.
               Otherwise, this is equal to the property `last_status_check`.
           experimental:
             type: boolean

--- a/extensions/federation/README.md
+++ b/extensions/federation/README.md
@@ -59,10 +59,9 @@ schema:
             format: date-time
             description: The time at which the status of the back-end was checked last.
           last_successful_check:
-            type:
-              - type: string
-                format: date-time
-              - type: null
+            type: string
+            format: date-time
+            nullable: true
             description: >-
               If the `status` is `offline`: The time at which the back-end was checked and available the last time
               or `null` when the back-end was never observed to be available.


### PR DESCRIPTION
when back-end was never observed to be available