### PR TITLE
PR #564 finetuning of back-end "availability" terminology

### DIFF
--- a/extensions/federation/README.md
+++ b/extensions/federation/README.md
@@ -108,8 +108,10 @@ schema:
 
 ## Resources supported only by a subset of back-ends
 
-Every discoverable resource that is defined as an object and allows to contain additional properties, can list the subset of back-ends that permanently support or host the exposed resource/functionality.
-Examples of where this could apply to (**not** comprehensive):
+Discoverable resources can explicitly list the subset of back-ends that support or host the exposed resource or functionality with the property `federation:backends`.
+
+Schema-wise, this only applies to resources that are defined as an object and allow to contain additional properties.
+For example (**not** comprehensive):
 
 - `GET /collections`
 - `GET /collections/{id}`
@@ -198,9 +200,9 @@ This also covers the case where the federation supports splitting a process into
 ## Temporarily or unintentionally unavailable resources
 
 Resources and back-ends can be temporarily or unintentionally unavailable.
-It is especially important to communicate to users missing resources when compiling lists of resources across multiple back-ends.
-Clients will assume that all lists of resources are the a combination of all back-ends listed under`federation` in `GET /`.
-Federated APIs can expose if any of the back-ends is temporarily not available and thus is not part of the response.
+It is especially important to communicate to users missing resources when compiling a **list of resources** across multiple back-ends.
+Clients will assume that all lists of resources are a combination of all back-ends listed under `federation` in `GET /`.
+Federated APIs can expose if any of the back-ends was not available when building the resource listing response with the property `federation:missing`.
 
 Examples of where this could apply to (**not** comprehensive):
 
@@ -223,7 +225,7 @@ schema:
   properties:
     'federation:missing':
       description: >-
-        Lists all back-ends that were temporarily not considered in the response (e.g. because they were not accessible).
+        Lists all back-ends that were unexpectedly unavailable during compilation of the response.
         If not given or empty, all back-ends supporting this endpoint were considered for creating the response.
         Back-ends that are listed as offline in the capabilities still need to be listed here.
       type: array


### PR DESCRIPTION
This is an auxiliary PR for #564 . To be merged or cherry-picked from

Main goal is to eliminate/reduce  "permanent"/"temporary" terminology which might make cause a mismatch in expectations as I tried to argue in https://github.com/Open-EO/openeo-api/pull/564#issuecomment-2909544291 

contents:
- explicitly mention  properties `federation:backends` and `federation:missing` in the descriptions
- eliminate the word "permanently" (used once for `federation:backends`), which was redundant in my opinion
- put `list of resources` in bold to (hopefully) make it more clear that `federation:backends` is for individual resources and `federation:missing` is for compiled listings
- reduce usage of "temporary"  and replace it with a neutral "not available". I kept it when used in combination "temporarily or unintentionally" where it has value.
- small typo fix of "the a combination"