### PR TITLE
`GET /udf_runtimes`: Requires at least one UDF runtime to be provided…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `queued`, `started` and `unpublished` to the batch job metadata and the corresponding STAC results [#542](https://github.com/Open-EO/openeo-api/issues/542)
 - Added all the batch job timestamps (including the new timestamps above) to the Collection type of batch job results
 
+### Changed
+
+- `GET /udf_runtimes`: Requires at least one UDF runtime to be provided. [#511](https://github.com/Open-EO/openeo-api/issues/511)
+
 ### Fixed
 
 - `GET /file_formats`: Base parameter on top of normal JSON Schema, not Process JSON Schema

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1810,6 +1810,7 @@ paths:
                   * For programming langauge environments use the names as provided
                     in in the [Scriptol List of Programming Languages](https://www.scriptol.com/programming/list-programming-languages.php).
                   * For docker images use the docker image identifier excluding the registry path.
+                minProperties: 1
                 additionalProperties:
                   x-additionalPropertiesName: UDF Runtime name
                   allOf:


### PR DESCRIPTION
Closing #511