### PR TITLE
`GET /credentials/oidc`: Added `authorization_parameters` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **New extensions:**
   - [Remote Process Definition Extension](./extensions/remote-process-definition/README.md)
   - [Processing Parameters Extension](./extensions/processing-parameters/README.md)
+- `GET /credentials/oidc`: Added `authorization_parameters` property to enforce specific parameters for the authorization endpoint [#534](https://github.com/Open-EO/openeo-api/issues/534)
 - `POST /result`: Added response header "OpenEO-Identifier" to expose an identifier associated with a synchronous processing request.
 - Added `version` property to `GET /processes` [#517](https://github.com/Open-EO/openeo-api/issues/517)
 - Added `queued`, `started` and `unpublished` to the batch job metadata and the corresponding STAC results [#542](https://github.com/Open-EO/openeo-api/issues/542)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2052,6 +2052,15 @@ paths:
                                 items:
                                   type: string
                                   format: uri
+                        authorization_parameters:
+                          type: object
+                          description: |-
+                            Additional parameters that an openEO client MUST include when requesting the authorization endpoint.
+                            This can be used to enforce specific
+                            [request parameters such as `prompt`](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest).
+                          example:
+                            prompt: consent
+                            access_type: offline
                         links:
                           type: array
                           description: |-
@@ -2090,6 +2099,8 @@ paths:
                       - profile
                       - email
                       - earthengine
+                    authorization_parameters:
+                      access_type: offline
                   - id: ms
                     issuer: 'https://login.microsoftonline.com/example-tenant/v2.0'
                     title: Microsoft


### PR DESCRIPTION
Closes #534 

`GET /credentials/oidc`: Added `authorization_parameters` property to enforce specific parameters for the authorization endpoint

I wasn't sure whether it should be per identity provider or per (default) client. Any thoughts?