### PR TITLE
Added `stacktrace` to log entries #512

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [Remote Process Definition Extension](./extensions/remote-process-definition/README.md)
   - [Processing Parameters Extension](./extensions/processing-parameters/README.md)
 - `POST /result`: Added response header "OpenEO-Identifier" to expose an identifier associated with a synchronous processing request.
+- Added `stacktrace` to log entries (e.g. for `GET /jobs/{job_id}/logs`) [#512](https://github.com/Open-EO/openeo-api/issues/512)
 - Added `version` property to `GET /processes` [#517](https://github.com/Open-EO/openeo-api/issues/517)
 - Added `queued`, `started` and `unpublished` to the batch job metadata and the corresponding STAC results [#542](https://github.com/Open-EO/openeo-api/issues/542)
 - Added all the batch job timestamps (including the new timestamps above) to the Collection type of batch job results

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6475,6 +6475,10 @@ components:
                 example: udf
         usage:
           $ref: '#/components/schemas/usage'
+        stacktrace:
+          type: string
+          description: >-
+            A stacktrace or similar, may include whitespaces for formatting.
         links:
           $ref: '#/components/schemas/log_links'
     usage:


### PR DESCRIPTION
Adds a simple `stacktrace property` to the log entry schema, to be used by services, jobs and sync. processing.

There was a lot of discussion in #512 around how to structure them, with generally 3 options:
1. Simple string
2. Array of strings
3. Array of objects (with e.g. file, line, src, etc.)

While 3 seems like the nicest solution, it might be difficult to implement as only a subset of languages actually implement that by default.
The decision between simple string and array of string was based on the following arguments:
- It is unclear where to split
- The programming languages usually do a relatively good job at indenting the stacktrace. Splitting it may remove the whitespace (e.g. for source code annotations) and as such it might be the best to just keep it as a plain string that can be formatted in the client with monospaced font, which is easily possible e.g. in the CLI and in web tooling.

This way we solve the primary objectives:
1. to remove the stacktrace from the (error) message
2. to provide a predicatble and user friendly way of inspecting the stack traces