### PR TITLE
Allow collections to be flagged as experimental

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Collections can be flagged as `experimental`
+
 ### Deprecated
 
 ### Changed

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4398,6 +4398,8 @@ components:
             This property REQUIRES to add `version` (STAC < 1.0.0-rc.1) or
             `https://stac-extensions.github.io/version/v1.2.0/schema.json` (STAC >= 1.0.0-rc.1)
             to the list of `stac_extensions`.
+        experimental:
+          $ref: '#/components/schemas/experimental'
         license:
           $ref: '#/components/schemas/stac_license'
         providers:


### PR DESCRIPTION
Most resources (processes, file formats, service types, runtimes, ...) can be flagged as experimental, but that's not possible with collections apparently.

Not sure if this is intended for some reason (STAC compatibility?) or an accidental oversight

This PR tries to fix that